### PR TITLE
feat: Issue #24 シードデータ投入スクリプトを作成

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -2,8 +2,9 @@
 # このファイルをコピーして .env.local を作成してください
 # cp .env.local.example .env.local
 
-# データベース接続文字列
-DATABASE_URL="mongodb://localhost:27017/sales_daily_report"
+# データベース接続文字列（レプリカセット対応）
+# レプリカセットを使用することで、Prismaのトランザクション機能が利用可能になります
+DATABASE_URL="mongodb://localhost:27017/sales_daily_report?replicaSet=rs0&directConnection=true"
 
 # セッション秘密鍵（開発環境用）
 # 本番環境では必ず変更してください

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,7 @@ services:
       # 本番環境では必ず認証を有効化すること
       # ローカル開発では認証なしで運用（簡便性のため）
       MONGO_INITDB_DATABASE: sales_daily_report
+    command: ['--replSet', 'rs0', '--bind_ip_all']
     volumes:
       # データの永続化（ホストマシンにデータを保存）
       - mongodb_data:/data/db
@@ -16,6 +17,8 @@ services:
       - mongodb_config:/data/configdb
       # 初期化スクリプト（必要に応じて）
       - ./docker/mongodb/init-mongo.js:/docker-entrypoint-initdb.d/init-mongo.js:ro
+      # レプリカセット初期化スクリプト
+      - ./docker/mongodb/init-replica.sh:/docker-entrypoint-initdb.d/init-replica.sh:ro
     networks:
       - sales_daily_report_network
     healthcheck:

--- a/docker/mongodb/init-replica.sh
+++ b/docker/mongodb/init-replica.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+# MongoDBレプリカセットの初期化スクリプト
+# このスクリプトは開発環境用で、単一ノードのレプリカセットを構成します
+
+echo "Waiting for MongoDB to start..."
+sleep 5
+
+echo "Checking if replica set is already initialized..."
+if mongosh --quiet --eval "rs.status().ok" | grep -q "1"; then
+  echo "Replica set is already initialized."
+  exit 0
+fi
+
+echo "Initializing replica set..."
+mongosh --eval '
+try {
+  var result = rs.initiate({
+    _id: "rs0",
+    members: [
+      { _id: 0, host: "localhost:27017" }
+    ]
+  });
+  print("Replica set initialization result:", JSON.stringify(result));
+  if (result.ok === 1) {
+    print("Replica set initialized successfully!");
+  } else {
+    print("Replica set initialization returned ok != 1");
+  }
+} catch (e) {
+  if (e.codeName === "AlreadyInitialized") {
+    print("Replica set is already initialized (caught exception).");
+  } else {
+    print("Error initializing replica set:", e);
+    throw e;
+  }
+}
+'
+
+echo "Replica set initialization completed!"

--- a/package.json
+++ b/package.json
@@ -27,9 +27,10 @@
     "db:clean": "docker compose down -v",
     "db:test": "tsx scripts/test-db-connection.ts",
     "db:push": "dotenv -e .env.local -- prisma db push",
-    "db:seed": "tsx scripts/seed.ts",
+    "db:seed": "prisma db seed",
     "db:tools": "docker compose --profile tools up -d",
-    "db:setup": "npm run db:up && npm run db:test && npm run db:push"
+    "db:init-replica": "bash scripts/init-mongo-replica.sh",
+    "db:setup": "npm run db:up && npm run db:init-replica && npm run db:test && npm run db:push"
   },
   "dependencies": {
     "@prisma/client": "^5.22.0",
@@ -80,5 +81,8 @@
     "**/*.{json,md,css}": [
       "prettier --write"
     ]
+  },
+  "prisma": {
+    "seed": "dotenv -e .env.local -- tsx prisma/seed.ts"
   }
 }

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1,0 +1,342 @@
+/* eslint-disable no-console */
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { PrismaClient, ReportStatus, CommentType } from '@prisma/client';
+import * as bcrypt from 'bcryptjs';
+
+const prisma = new PrismaClient();
+
+/**
+ * 本番環境での誤実行を防止
+ */
+function checkEnvironment() {
+  const nodeEnv = process.env.NODE_ENV;
+  const allowSeed = process.env.ALLOW_SEED;
+
+  if (nodeEnv === 'production' && allowSeed !== 'true') {
+    console.error('❌ ERROR: Seeding is not allowed in production environment!');
+    console.error('If you really want to seed in production, set ALLOW_SEED=true');
+    process.exit(1);
+  }
+
+  console.log(`🌱 Seeding database in ${nodeEnv || 'development'} environment...`);
+}
+
+/**
+ * パスワードをハッシュ化
+ */
+async function hashPassword(password: string): Promise<string> {
+  return await bcrypt.hash(password, 10);
+}
+
+/**
+ * 営業マスタのシードデータを投入
+ */
+async function seedSales() {
+  console.log('📊 Seeding Sales data...');
+
+  // マネージャー1: 山田太郎
+  const manager1 = await prisma.sales.upsert({
+    where: { salesCode: 'MGR001' },
+    update: {},
+    create: {
+      salesCode: 'MGR001',
+      salesName: '山田太郎',
+      email: 'yamada@example.com',
+      passwordHash: await hashPassword('password123'),
+      department: '営業1課',
+      isManager: true,
+    },
+  });
+
+  // 営業1: 佐藤花子
+  const sales1 = await prisma.sales.upsert({
+    where: { salesCode: 'S001' },
+    update: {},
+    create: {
+      salesCode: 'S001',
+      salesName: '佐藤花子',
+      email: 'sato@example.com',
+      passwordHash: await hashPassword('password123'),
+      department: '営業1課',
+      isManager: false,
+      managerId: manager1.id,
+    },
+  });
+
+  // 営業2: 鈴木一郎
+  const sales2 = await prisma.sales.upsert({
+    where: { salesCode: 'S002' },
+    update: {},
+    create: {
+      salesCode: 'S002',
+      salesName: '鈴木一郎',
+      email: 'suzuki@example.com',
+      passwordHash: await hashPassword('password123'),
+      department: '営業2課',
+      isManager: false,
+    },
+  });
+
+  // マネージャー2: 田中次郎
+  const manager2 = await prisma.sales.upsert({
+    where: { salesCode: 'MGR002' },
+    update: {},
+    create: {
+      salesCode: 'MGR002',
+      salesName: '田中次郎',
+      email: 'tanaka@example.com',
+      passwordHash: await hashPassword('password123'),
+      department: '営業2課',
+      isManager: true,
+    },
+  });
+
+  // 鈴木一郎のマネージャーを田中次郎に設定
+  await prisma.sales.update({
+    where: { id: sales2.id },
+    data: { managerId: manager2.id },
+  });
+
+  console.log('✅ Sales data seeded successfully');
+  return { manager1, sales1, sales2, manager2 };
+}
+
+/**
+ * 顧客マスタのシードデータを投入
+ */
+async function seedCustomers(sales: { sales1: any; sales2: any }) {
+  console.log('🏢 Seeding Customer data...');
+
+  const customer1 = await prisma.customer.upsert({
+    where: { customerCode: 'C001' },
+    update: {},
+    create: {
+      customerCode: 'C001',
+      customerName: 'A株式会社',
+      industry: '製造業',
+      phone: '03-1234-5678',
+      salesId: sales.sales1.id,
+    },
+  });
+
+  const customer2 = await prisma.customer.upsert({
+    where: { customerCode: 'C002' },
+    update: {},
+    create: {
+      customerCode: 'C002',
+      customerName: 'B株式会社',
+      industry: 'IT',
+      phone: '03-2345-6789',
+      salesId: sales.sales1.id,
+    },
+  });
+
+  const customer3 = await prisma.customer.upsert({
+    where: { customerCode: 'C003' },
+    update: {},
+    create: {
+      customerCode: 'C003',
+      customerName: 'C商事',
+      industry: 'サービス',
+      phone: '06-3456-7890',
+      salesId: sales.sales2.id,
+    },
+  });
+
+  console.log('✅ Customer data seeded successfully');
+  return { customer1, customer2, customer3 };
+}
+
+/**
+ * 日報サンプルデータを投入（過去1週間分）
+ */
+async function seedDailyReports(
+  sales: { sales1: any; sales2: any },
+  customers: { customer1: any; customer2: any; customer3: any }
+) {
+  console.log('📝 Seeding Daily Report data...');
+
+  const today = new Date();
+  const reports = [];
+
+  // 過去7日分の日報を作成
+  for (let i = 0; i < 7; i++) {
+    const reportDate = new Date(today);
+    reportDate.setDate(today.getDate() - i);
+    reportDate.setHours(0, 0, 0, 0);
+
+    // 佐藤花子の日報
+    const report1 = await prisma.dailyReport.upsert({
+      where: {
+        unique_sales_report_date: {
+          salesId: sales.sales1.id,
+          reportDate: reportDate,
+        },
+      },
+      update: {},
+      create: {
+        salesId: sales.sales1.id,
+        reportDate: reportDate,
+        problem: i % 2 === 0 ? `${i + 1}日前の課題: 新規顧客開拓が進んでいません` : null,
+        plan: i % 2 === 0 ? `${i + 1}日前の計画: 既存顧客へのフォローアップを強化します` : null,
+        status: i < 2 ? ReportStatus.SUBMITTED : ReportStatus.DRAFT,
+        submittedAt: i < 2 ? new Date(reportDate.getTime() + 18 * 60 * 60 * 1000) : null,
+      },
+    });
+
+    // 訪問記録を1〜3件追加
+    const visitCount = Math.min((i % 3) + 1, 3);
+    for (let j = 0; j < visitCount; j++) {
+      const visitDatetime = new Date(reportDate);
+      visitDatetime.setHours(10 + j * 2, 0, 0, 0);
+
+      const customerId = j === 0 ? customers.customer1.id : customers.customer2.id;
+
+      await prisma.visitRecord.create({
+        data: {
+          reportId: report1.id,
+          customerId: customerId,
+          visitDatetime: visitDatetime,
+          visitContent: `訪問内容${j + 1}: 製品の提案と見積もりの提出`,
+          visitResult: j % 2 === 0 ? `訪問結果${j + 1}: 好感触、次回アポイント取得` : null,
+          displayOrder: j,
+        },
+      });
+    }
+
+    reports.push(report1);
+
+    // 鈴木一郎の日報（3日に1回）
+    if (i % 3 === 0) {
+      const report2 = await prisma.dailyReport.upsert({
+        where: {
+          unique_sales_report_date: {
+            salesId: sales.sales2.id,
+            reportDate: reportDate,
+          },
+        },
+        update: {},
+        create: {
+          salesId: sales.sales2.id,
+          reportDate: reportDate,
+          problem: null,
+          plan: `${i + 1}日前の計画: C商事との契約交渉を進めます`,
+          status: i < 2 ? ReportStatus.SUBMITTED : ReportStatus.DRAFT,
+          submittedAt: i < 2 ? new Date(reportDate.getTime() + 17 * 60 * 60 * 1000) : null,
+        },
+      });
+
+      // 訪問記録を1件追加
+      const visitDatetime = new Date(reportDate);
+      visitDatetime.setHours(14, 0, 0, 0);
+
+      await prisma.visitRecord.create({
+        data: {
+          reportId: report2.id,
+          customerId: customers.customer3.id,
+          visitDatetime: visitDatetime,
+          visitContent: '契約条件の確認と調整',
+          visitResult: '価格交渉継続中',
+          displayOrder: 0,
+        },
+      });
+
+      reports.push(report2);
+    }
+  }
+
+  console.log('✅ Daily Report data seeded successfully');
+  return reports;
+}
+
+/**
+ * コメントサンプルデータを投入
+ */
+async function seedComments(reports: any[], managers: { manager1: any; manager2: any }) {
+  console.log('💬 Seeding Comment data...');
+
+  // 最新の2件の日報にコメントを追加
+  const submittedReports = reports.filter((r) => r.status === ReportStatus.SUBMITTED).slice(0, 2);
+
+  for (const report of submittedReports) {
+    // 課題へのコメント
+    if (report.problem) {
+      await prisma.comment.create({
+        data: {
+          reportId: report.id,
+          commenterId: managers.manager1.id,
+          commentType: CommentType.PROBLEM,
+          commentText: '新規顧客開拓については、マーケティング部門と連携して進めてください。',
+          isRead: false,
+        },
+      });
+    }
+
+    // 計画へのコメント
+    if (report.plan) {
+      await prisma.comment.create({
+        data: {
+          reportId: report.id,
+          commenterId: managers.manager1.id,
+          commentType: CommentType.PLAN,
+          commentText: 'フォローアップの頻度を上げることで、顧客満足度向上につながると思います。',
+          isRead: false,
+        },
+      });
+    }
+  }
+
+  console.log('✅ Comment data seeded successfully');
+}
+
+/**
+ * メイン処理
+ */
+async function main() {
+  try {
+    checkEnvironment();
+
+    // 既存データのクリーンアップ（開発環境のみ）
+    if (process.env.NODE_ENV !== 'production') {
+      console.log('🧹 Cleaning up existing data...');
+      await prisma.comment.deleteMany();
+      await prisma.visitRecord.deleteMany();
+      await prisma.dailyReport.deleteMany();
+      await prisma.customer.deleteMany();
+      await prisma.sales.deleteMany();
+      console.log('✅ Cleanup completed');
+    }
+
+    const salesData = await seedSales();
+    const customerData = await seedCustomers({
+      sales1: salesData.sales1,
+      sales2: salesData.sales2,
+    });
+    const reports = await seedDailyReports(salesData, customerData);
+    await seedComments(reports, {
+      manager1: salesData.manager1,
+      manager2: salesData.manager2,
+    });
+
+    console.log('🎉 All seed data inserted successfully!');
+    console.log('');
+    console.log('📋 Summary:');
+    console.log('  - Sales: 4 records (2 managers, 2 staff)');
+    console.log('  - Customers: 3 records');
+    console.log(`  - Daily Reports: ${reports.length} records`);
+    console.log('  - Visit Records: Multiple records');
+    console.log('  - Comments: Added to recent submitted reports');
+    console.log('');
+    console.log('🔑 Default password for all users: password123');
+  } catch (error) {
+    console.error('❌ Error seeding data:', error);
+    throw error;
+  } finally {
+    await prisma.$disconnect();
+  }
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/scripts/init-mongo-replica.sh
+++ b/scripts/init-mongo-replica.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+# MongoDBレプリカセットの初期化を確実に実行するスクリプト
+# docker-compose up 後にこのスクリプトを実行してください
+
+echo "🔍 Checking MongoDB container status..."
+
+# MongoDBコンテナが起動するまで待機
+until docker exec sales_daily_report_mongodb mongosh --quiet --eval "db.adminCommand('ping')" > /dev/null 2>&1; do
+  echo "⏳ Waiting for MongoDB to be ready..."
+  sleep 2
+done
+
+echo "✅ MongoDB is ready"
+
+# レプリカセットが既に初期化されているかチェック
+echo "🔍 Checking if replica set is already initialized..."
+if docker exec sales_daily_report_mongodb mongosh --quiet --eval "try { rs.status().ok } catch(e) { 0 }" | grep -q "1"; then
+  echo "✅ Replica set is already initialized."
+  exit 0
+fi
+
+# レプリカセットを初期化
+echo "🚀 Initializing replica set..."
+docker exec sales_daily_report_mongodb mongosh --eval '
+try {
+  var result = rs.initiate({
+    _id: "rs0",
+    members: [
+      { _id: 0, host: "localhost:27017" }
+    ]
+  });
+  if (result.ok === 1) {
+    print("✅ Replica set initialized successfully!");
+  } else {
+    print("⚠️  Replica set initialization returned:", JSON.stringify(result));
+  }
+} catch (e) {
+  if (e.codeName === "AlreadyInitialized") {
+    print("ℹ️  Replica set is already initialized.");
+  } else {
+    print("❌ Error initializing replica set:", e);
+    throw e;
+  }
+}
+'
+
+echo "🎉 Replica set setup completed!"


### PR DESCRIPTION
## 概要
Issue #24の実装です。開発・テスト用のシードデータを投入するスクリプトを作成しました。

## 実装内容

### 1. シードスクリプト (prisma/seed.ts)
- 営業マスタ（4件: マネージャー2名、営業担当2名）
- 顧客マスタ（3件: 製造業、IT、サービス業の顧客）
- 日報サンプル（過去7日分、計10件）
- 訪問記録（各日報に1〜3件）
- コメントサンプル（最新の提出済み日報にコメント）

### 2. セキュリティ機能
- bcryptjsでパスワードをハッシュ化（デフォルト: `password123`）
- 本番環境での誤実行防止機能
  - `NODE_ENV=production`の場合、`ALLOW_SEED=true`が明示的に設定されていない限り実行を拒否

### 3. MongoDBレプリカセット設定
- Prismaのトランザクション機能を使用するため、MongoDBをレプリカセットとして設定
- `docker-compose.yml`にレプリカセット設定を追加
- レプリカセット自動初期化スクリプト（`scripts/init-mongo-replica.sh`）を作成
- `npm run db:init-replica`で手動初期化も可能

### 4. package.jsonへの追加
- `db:seed`: シードデータを投入（`prisma db seed`）
- `db:init-replica`: レプリカセットを初期化
- `db:setup`: データベースのセットアップを一括実行（起動 → レプリカセット初期化 → 接続テスト → スキーマ適用）

### 5. 環境変数の更新
- `.env.local.example`のDATABASE_URLをレプリカセット対応に更新
- 接続文字列: `mongodb://localhost:27017/sales_daily_report?replicaSet=rs0&directConnection=true`

## 使用方法

```bash
# 初回セットアップ（データベース起動 + レプリカセット初期化 + スキーマ適用）
npm run db:setup

# シードデータ投入
npm run db:seed

# 既存環境でレプリカセットが未初期化の場合
npm run db:init-replica
```

## テスト
- ✅ シードデータの投入が正常に動作することを確認
- ✅ Lintエラーなし
- ✅ Type checkエラーなし
- ✅ 冪等性確認（複数回実行しても安全）

## 備考
- シードスクリプトは`upsert`を使用しているため、何度実行しても冪等性が保たれます
- レプリカセットが初期化されていない場合、`npm run db:init-replica`で初期化してください

🤖 Generated with [Claude Code](https://claude.com/claude-code)