### PR TITLE
feat: Issue #11 顧客マスタAPIを実装する

### DIFF
--- a/app/api/customers/[id]/__tests__/route.test.ts
+++ b/app/api/customers/[id]/__tests__/route.test.ts
@@ -1,0 +1,447 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { GET, PUT, DELETE } from '../route';
+import { NextRequest } from 'next/server';
+
+// vi.hoisted を使ってモック関数を定義
+const mockCustomerFindUnique = vi.hoisted(() => vi.fn());
+const mockCustomerUpdate = vi.hoisted(() => vi.fn());
+const mockCustomerDelete = vi.hoisted(() => vi.fn());
+const mockSalesFindUnique = vi.hoisted(() => vi.fn());
+const mockVisitRecordCount = vi.hoisted(() => vi.fn());
+const mockDisconnect = vi.hoisted(() => vi.fn());
+
+// モックの設定
+vi.mock('@prisma/client', () => {
+  class MockPrismaClient {
+    customer = {
+      findUnique: mockCustomerFindUnique,
+      update: mockCustomerUpdate,
+      delete: mockCustomerDelete,
+    };
+    sales = {
+      findUnique: mockSalesFindUnique,
+    };
+    visitRecord = {
+      count: mockVisitRecordCount,
+    };
+    $disconnect = mockDisconnect;
+  }
+
+  return {
+    PrismaClient: MockPrismaClient,
+  };
+});
+
+vi.mock('@/lib/middleware/auth', () => ({
+  requireAuth: vi.fn(),
+}));
+
+// テスト用のヘルパー関数
+const mockAuth = async () => {
+  const { requireAuth } = await import('@/lib/middleware/auth');
+  vi.mocked(requireAuth).mockResolvedValue({
+    session: {
+      salesId: 'sales-id-1',
+      salesCode: 'S001',
+      salesName: '佐藤花子',
+      email: 'sato@example.com',
+      department: '営業1課',
+      isManager: false,
+      expiresAt: Date.now() + 30 * 60 * 1000,
+    },
+    error: null,
+  } as any);
+};
+
+const mockUnauthorized = async () => {
+  const { requireAuth } = await import('@/lib/middleware/auth');
+  const errorResponse = {
+    status: 'error',
+    error: {
+      code: 'AUTH_UNAUTHORIZED',
+      message: '認証が必要です',
+    },
+  };
+
+  vi.mocked(requireAuth).mockResolvedValue({
+    session: null,
+    error: true,
+    response: {
+      json: () => Promise.resolve(errorResponse),
+      status: 401,
+    } as any,
+  });
+};
+
+describe('GET /api/customers/[id]', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('認証済みユーザーは顧客詳細を取得できる', async () => {
+    await mockAuth();
+
+    const validCustomerId = '507f1f77bcf86cd799439011'; // Valid MongoDB ObjectId
+    const validSalesId = '507f1f77bcf86cd799439022'; // Valid MongoDB ObjectId
+
+    mockCustomerFindUnique.mockResolvedValue({
+      id: validCustomerId,
+      customerCode: 'C001',
+      customerName: 'A株式会社',
+      industry: '製造業',
+      postalCode: '100-0001',
+      address: '東京都千代田区千代田1-1-1',
+      phone: '03-1234-5678',
+      salesId: validSalesId,
+      notes: '重要顧客',
+      createdAt: new Date('2025-12-01T10:00:00Z'),
+      updatedAt: new Date('2026-01-10T15:00:00Z'),
+      sales: {
+        id: validSalesId,
+        salesName: '佐藤花子',
+        department: {
+          departmentName: '営業1課',
+        },
+      },
+    });
+
+    const params = Promise.resolve({ id: validCustomerId });
+    const request = new NextRequest(`http://localhost/api/customers/${validCustomerId}`);
+
+    const response = await GET(request, { params });
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.status).toBe('success');
+    expect(data.data.customer_code).toBe('C001');
+    expect(data.data.customer_name).toBe('A株式会社');
+    expect(data.data.sales.sales_name).toBe('佐藤花子');
+    expect(data.data.sales.department).toBe('営業1課');
+    expect(data.data.notes).toBe('重要顧客');
+  });
+
+  it('顧客が存在しない場合、404エラーを返す', async () => {
+    await mockAuth();
+
+    mockCustomerFindUnique.mockResolvedValue(null);
+
+    const params = Promise.resolve({ id: '507f1f77bcf86cd799439011' });
+    const request = new NextRequest('http://localhost/api/customers/507f1f77bcf86cd799439011');
+
+    const response = await GET(request, { params });
+    const data = await response.json();
+
+    expect(response.status).toBe(404);
+    expect(data.status).toBe('error');
+    expect(data.error.code).toBe('RESOURCE_NOT_FOUND');
+  });
+
+  it('無効な顧客IDの場合、400エラーを返す', async () => {
+    await mockAuth();
+
+    const params = Promise.resolve({ id: 'invalid-id' });
+    const request = new NextRequest('http://localhost/api/customers/invalid-id');
+
+    const response = await GET(request, { params });
+    const data = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(data.status).toBe('error');
+    expect(data.error.code).toBe('VALIDATION_ERROR');
+  });
+
+  it('未認証ユーザーはアクセス拒否される', async () => {
+    await mockUnauthorized();
+
+    const validCustomerId = '507f1f77bcf86cd799439011';
+    const params = Promise.resolve({ id: validCustomerId });
+    const request = new NextRequest(`http://localhost/api/customers/${validCustomerId}`);
+
+    const response = await GET(request, { params });
+
+    expect(response.status).toBe(401);
+  });
+});
+
+describe('PUT /api/customers/[id]', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('認証済みユーザーは顧客を更新できる', async () => {
+    await mockAuth();
+
+    const validCustomerId = '507f1f77bcf86cd799439011';
+    const validSalesId = '507f1f77bcf86cd799439022';
+
+    // 顧客が存在する
+    mockCustomerFindUnique.mockResolvedValueOnce({
+      id: validCustomerId,
+      customerCode: 'C001',
+      customerName: 'A株式会社',
+    } as any);
+
+    // 営業が存在する
+    mockSalesFindUnique.mockResolvedValueOnce({
+      id: validSalesId,
+      salesCode: 'S002',
+      salesName: '鈴木一郎',
+    } as any);
+
+    mockCustomerUpdate.mockResolvedValue({
+      id: validCustomerId,
+      customerCode: 'C001',
+      customerName: 'A株式会社（更新）',
+      industry: '製造業',
+      postalCode: '100-0002',
+      address: '東京都千代田区千代田2-2-2',
+      phone: '03-9876-5432',
+      salesId: validSalesId,
+      notes: '住所変更あり',
+      updatedAt: new Date('2026-01-18T11:00:00Z'),
+    });
+
+    const params = Promise.resolve({ id: validCustomerId });
+    const request = new NextRequest(`http://localhost/api/customers/${validCustomerId}`, {
+      method: 'PUT',
+      body: JSON.stringify({
+        customer_name: 'A株式会社（更新）',
+        industry: '製造業',
+        postal_code: '100-0002',
+        address: '東京都千代田区千代田2-2-2',
+        phone: '03-9876-5432',
+        sales_id: validSalesId,
+        notes: '住所変更あり',
+      }),
+    });
+
+    const response = await PUT(request, { params });
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.status).toBe('success');
+    expect(data.data.customer_id).toBe(validCustomerId);
+    expect(mockCustomerUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: validCustomerId },
+        data: expect.objectContaining({
+          customerName: 'A株式会社（更新）',
+          industry: '製造業',
+          postalCode: '100-0002',
+          address: '東京都千代田区千代田2-2-2',
+          phone: '03-9876-5432',
+          salesId: validSalesId,
+          notes: '住所変更あり',
+        }),
+      })
+    );
+  });
+
+  it('顧客が存在しない場合、404エラーを返す', async () => {
+    await mockAuth();
+
+    const validCustomerId = '507f1f77bcf86cd799439011';
+
+    mockCustomerFindUnique.mockResolvedValueOnce(null);
+
+    const params = Promise.resolve({ id: validCustomerId });
+    const request = new NextRequest(`http://localhost/api/customers/${validCustomerId}`, {
+      method: 'PUT',
+      body: JSON.stringify({
+        customer_name: 'A株式会社',
+        sales_id: '507f1f77bcf86cd799439022',
+      }),
+    });
+
+    const response = await PUT(request, { params });
+    const data = await response.json();
+
+    expect(response.status).toBe(404);
+    expect(data.status).toBe('error');
+    expect(data.error.code).toBe('RESOURCE_NOT_FOUND');
+  });
+
+  it('営業が存在しない場合、400エラーを返す', async () => {
+    await mockAuth();
+
+    const validCustomerId = '507f1f77bcf86cd799439011';
+    const invalidSalesId = '507f1f77bcf86cd799439099';
+
+    // 顧客が存在する
+    mockCustomerFindUnique.mockResolvedValueOnce({
+      id: validCustomerId,
+      customerCode: 'C001',
+    } as any);
+
+    // 営業が存在しない
+    mockSalesFindUnique.mockResolvedValueOnce(null);
+
+    const params = Promise.resolve({ id: validCustomerId });
+    const request = new NextRequest(`http://localhost/api/customers/${validCustomerId}`, {
+      method: 'PUT',
+      body: JSON.stringify({
+        customer_name: 'A株式会社',
+        sales_id: invalidSalesId,
+      }),
+    });
+
+    const response = await PUT(request, { params });
+    const data = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(data.status).toBe('error');
+    expect(data.error.code).toBe('VALIDATION_ERROR');
+  });
+
+  it('無効な顧客IDの場合、400エラーを返す', async () => {
+    await mockAuth();
+
+    const params = Promise.resolve({ id: 'invalid-id' });
+    const request = new NextRequest('http://localhost/api/customers/invalid-id', {
+      method: 'PUT',
+      body: JSON.stringify({
+        customer_name: 'A株式会社',
+        sales_id: '507f1f77bcf86cd799439011',
+      }),
+    });
+
+    const response = await PUT(request, { params });
+    const data = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(data.status).toBe('error');
+    expect(data.error.code).toBe('VALIDATION_ERROR');
+  });
+
+  it('未認証ユーザーは顧客を更新できない', async () => {
+    await mockUnauthorized();
+
+    const params = Promise.resolve({ id: '507f1f77bcf86cd799439011' });
+    const request = new NextRequest('http://localhost/api/customers/507f1f77bcf86cd799439011', {
+      method: 'PUT',
+      body: JSON.stringify({
+        customer_name: 'A株式会社',
+        sales_id: '507f1f77bcf86cd799439022',
+      }),
+    });
+
+    const response = await PUT(request, { params });
+
+    expect(response.status).toBe(401);
+  });
+});
+
+describe('DELETE /api/customers/[id]', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('認証済みユーザーは顧客を削除できる', async () => {
+    await mockAuth();
+
+    const validCustomerId = '507f1f77bcf86cd799439011';
+
+    // 顧客が存在する
+    mockCustomerFindUnique.mockResolvedValueOnce({
+      id: validCustomerId,
+      customerCode: 'C001',
+    } as any);
+
+    // 訪問記録で使用されていない
+    mockVisitRecordCount.mockResolvedValueOnce(0);
+
+    mockCustomerDelete.mockResolvedValue({
+      id: validCustomerId,
+    });
+
+    const params = Promise.resolve({ id: validCustomerId });
+    const request = new NextRequest(`http://localhost/api/customers/${validCustomerId}`, {
+      method: 'DELETE',
+    });
+
+    const response = await DELETE(request, { params });
+
+    expect(response.status).toBe(204);
+    expect(mockCustomerDelete).toHaveBeenCalledWith({
+      where: { id: validCustomerId },
+    });
+  });
+
+  it('顧客が存在しない場合、404エラーを返す', async () => {
+    await mockAuth();
+
+    const validCustomerId = '507f1f77bcf86cd799439011';
+
+    mockCustomerFindUnique.mockResolvedValueOnce(null);
+
+    const params = Promise.resolve({ id: validCustomerId });
+    const request = new NextRequest(`http://localhost/api/customers/${validCustomerId}`, {
+      method: 'DELETE',
+    });
+
+    const response = await DELETE(request, { params });
+    const data = await response.json();
+
+    expect(response.status).toBe(404);
+    expect(data.status).toBe('error');
+    expect(data.error.code).toBe('RESOURCE_NOT_FOUND');
+  });
+
+  it('訪問記録で使用されている場合、削除できない', async () => {
+    await mockAuth();
+
+    const validCustomerId = '507f1f77bcf86cd799439011';
+
+    // 顧客が存在する
+    mockCustomerFindUnique.mockResolvedValueOnce({
+      id: validCustomerId,
+      customerCode: 'C001',
+    } as any);
+
+    // 訪問記録で使用されている
+    mockVisitRecordCount.mockResolvedValueOnce(3);
+
+    const params = Promise.resolve({ id: validCustomerId });
+    const request = new NextRequest(`http://localhost/api/customers/${validCustomerId}`, {
+      method: 'DELETE',
+    });
+
+    const response = await DELETE(request, { params });
+    const data = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(data.status).toBe('error');
+    expect(data.error.code).toBe('RESOURCE_IN_USE');
+    expect(mockCustomerDelete).not.toHaveBeenCalled();
+  });
+
+  it('無効な顧客IDの場合、400エラーを返す', async () => {
+    await mockAuth();
+
+    const params = Promise.resolve({ id: 'invalid-id' });
+    const request = new NextRequest('http://localhost/api/customers/invalid-id', {
+      method: 'DELETE',
+    });
+
+    const response = await DELETE(request, { params });
+    const data = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(data.status).toBe('error');
+    expect(data.error.code).toBe('VALIDATION_ERROR');
+  });
+
+  it('未認証ユーザーは顧客を削除できない', async () => {
+    await mockUnauthorized();
+
+    const params = Promise.resolve({ id: '507f1f77bcf86cd799439011' });
+    const request = new NextRequest('http://localhost/api/customers/507f1f77bcf86cd799439011', {
+      method: 'DELETE',
+    });
+
+    const response = await DELETE(request, { params });
+
+    expect(response.status).toBe(401);
+  });
+});

--- a/app/api/customers/[id]/route.ts
+++ b/app/api/customers/[id]/route.ts
@@ -1,0 +1,328 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { PrismaClient } from '@prisma/client';
+import { requireAuth } from '@/lib/middleware/auth';
+import { updateCustomerSchema, formatZodErrors } from '@/lib/validations/customer';
+import type { ApiSuccessResponse, ApiErrorResponse } from '@/types/session';
+import type { CustomerDetailResponse, CustomerUpdateResponse } from '@/types/customer';
+
+const prisma = new PrismaClient();
+
+/**
+ * 顧客詳細取得API
+ *
+ * GET /api/customers/:id
+ *
+ * 認証済みユーザーのみアクセス可能
+ *
+ * @param request - Next.js Request オブジェクト
+ * @param params - パスパラメータ
+ * @returns 顧客詳細情報
+ */
+export async function GET(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  try {
+    // 認証チェック
+    const authResult = await requireAuth();
+    if (authResult.error) {
+      return authResult.response;
+    }
+
+    const { id } = await params;
+
+    // 顧客IDのバリデーション（MongoDB ObjectId）
+    if (!/^[0-9a-fA-F]{24}$/.test(id)) {
+      const errorResponse: ApiErrorResponse = {
+        status: 'error',
+        error: {
+          code: 'VALIDATION_ERROR',
+          message: '無効な顧客IDです',
+        },
+      };
+      return NextResponse.json(errorResponse, { status: 400 });
+    }
+
+    // 顧客データの取得
+    const customer = await prisma.customer.findUnique({
+      where: { id },
+      include: {
+        sales: {
+          select: {
+            id: true,
+            salesName: true,
+            department: {
+              select: {
+                departmentName: true,
+              },
+            },
+          },
+        },
+      },
+    });
+
+    if (!customer) {
+      const errorResponse: ApiErrorResponse = {
+        status: 'error',
+        error: {
+          code: 'RESOURCE_NOT_FOUND',
+          message: '顧客が見つかりません',
+        },
+      };
+      return NextResponse.json(errorResponse, { status: 404 });
+    }
+
+    // レスポンスの構築
+    const responseData: CustomerDetailResponse = {
+      customer_id: customer.id,
+      customer_code: customer.customerCode,
+      customer_name: customer.customerName,
+      industry: customer.industry ?? undefined,
+      postal_code: customer.postalCode ?? undefined,
+      address: customer.address ?? undefined,
+      phone: customer.phone ?? undefined,
+      sales: {
+        sales_id: customer.sales.id,
+        sales_name: customer.sales.salesName,
+        department: customer.sales.department.departmentName,
+      },
+      notes: customer.notes ?? undefined,
+      created_at: customer.createdAt.toISOString(),
+      updated_at: customer.updatedAt.toISOString(),
+    };
+
+    const successResponse: ApiSuccessResponse<CustomerDetailResponse> = {
+      status: 'success',
+      data: responseData,
+    };
+
+    return NextResponse.json(successResponse, { status: 200 });
+  } catch (error) {
+    console.error('Customer detail retrieval error:', error);
+    const errorResponse: ApiErrorResponse = {
+      status: 'error',
+      error: {
+        code: 'SERVER_ERROR',
+        message: 'サーバーエラーが発生しました',
+      },
+    };
+    return NextResponse.json(errorResponse, { status: 500 });
+  } finally {
+    await prisma.$disconnect();
+  }
+}
+
+/**
+ * 顧客更新API
+ *
+ * PUT /api/customers/:id
+ *
+ * 認証済みユーザーのみアクセス可能
+ * 顧客コードは変更不可
+ *
+ * @param request - Next.js Request オブジェクト
+ * @param params - パスパラメータ
+ * @returns 更新された顧客情報
+ */
+export async function PUT(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  try {
+    // 認証チェック
+    const authResult = await requireAuth();
+    if (authResult.error) {
+      return authResult.response;
+    }
+
+    const { id } = await params;
+
+    // 顧客IDのバリデーション（MongoDB ObjectId）
+    if (!/^[0-9a-fA-F]{24}$/.test(id)) {
+      const errorResponse: ApiErrorResponse = {
+        status: 'error',
+        error: {
+          code: 'VALIDATION_ERROR',
+          message: '無効な顧客IDです',
+        },
+      };
+      return NextResponse.json(errorResponse, { status: 400 });
+    }
+
+    // 顧客の存在確認
+    const existingCustomer = await prisma.customer.findUnique({
+      where: { id },
+    });
+
+    if (!existingCustomer) {
+      const errorResponse: ApiErrorResponse = {
+        status: 'error',
+        error: {
+          code: 'RESOURCE_NOT_FOUND',
+          message: '顧客が見つかりません',
+        },
+      };
+      return NextResponse.json(errorResponse, { status: 404 });
+    }
+
+    // リクエストボディの取得
+    const body = await request.json();
+
+    // バリデーション
+    const validationResult = updateCustomerSchema.safeParse(body);
+    if (!validationResult.success) {
+      const errorResponse: ApiErrorResponse = {
+        status: 'error',
+        error: {
+          code: 'VALIDATION_ERROR',
+          message: '入力内容に誤りがあります',
+          details: formatZodErrors(validationResult.error),
+        },
+      };
+      return NextResponse.json(errorResponse, { status: 400 });
+    }
+
+    const { customer_name, industry, postal_code, address, phone, sales_id, notes } =
+      validationResult.data;
+
+    // 営業IDの存在確認
+    const salesExists = await prisma.sales.findUnique({
+      where: { id: sales_id },
+    });
+
+    if (!salesExists) {
+      const errorResponse: ApiErrorResponse = {
+        status: 'error',
+        error: {
+          code: 'VALIDATION_ERROR',
+          message: '入力内容に誤りがあります',
+          details: [{ field: 'sales_id', message: '指定された営業が見つかりません' }],
+        },
+      };
+      return NextResponse.json(errorResponse, { status: 400 });
+    }
+
+    // 顧客の更新
+    const updatedCustomer = await prisma.customer.update({
+      where: { id },
+      data: {
+        customerName: customer_name,
+        industry: industry ?? null,
+        postalCode: postal_code ?? null,
+        address: address ?? null,
+        phone: phone ?? null,
+        salesId: sales_id,
+        notes: notes ?? null,
+      },
+    });
+
+    // レスポンスの構築
+    const responseData: CustomerUpdateResponse = {
+      customer_id: updatedCustomer.id,
+      updated_at: updatedCustomer.updatedAt.toISOString(),
+    };
+
+    const successResponse: ApiSuccessResponse<CustomerUpdateResponse> = {
+      status: 'success',
+      data: responseData,
+    };
+
+    return NextResponse.json(successResponse, { status: 200 });
+  } catch (error) {
+    console.error('Customer update error:', error);
+    const errorResponse: ApiErrorResponse = {
+      status: 'error',
+      error: {
+        code: 'SERVER_ERROR',
+        message: 'サーバーエラーが発生しました',
+      },
+    };
+    return NextResponse.json(errorResponse, { status: 500 });
+  } finally {
+    await prisma.$disconnect();
+  }
+}
+
+/**
+ * 顧客削除API
+ *
+ * DELETE /api/customers/:id
+ *
+ * 認証済みユーザーのみアクセス可能
+ * 日報（訪問記録）で使用中の場合は削除不可
+ *
+ * @param request - Next.js Request オブジェクト
+ * @param params - パスパラメータ
+ * @returns 削除成功時は204 No Content
+ */
+export async function DELETE(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    // 認証チェック
+    const authResult = await requireAuth();
+    if (authResult.error) {
+      return authResult.response;
+    }
+
+    const { id } = await params;
+
+    // 顧客IDのバリデーション（MongoDB ObjectId）
+    if (!/^[0-9a-fA-F]{24}$/.test(id)) {
+      const errorResponse: ApiErrorResponse = {
+        status: 'error',
+        error: {
+          code: 'VALIDATION_ERROR',
+          message: '無効な顧客IDです',
+        },
+      };
+      return NextResponse.json(errorResponse, { status: 400 });
+    }
+
+    // 顧客の存在確認
+    const existingCustomer = await prisma.customer.findUnique({
+      where: { id },
+    });
+
+    if (!existingCustomer) {
+      const errorResponse: ApiErrorResponse = {
+        status: 'error',
+        error: {
+          code: 'RESOURCE_NOT_FOUND',
+          message: '顧客が見つかりません',
+        },
+      };
+      return NextResponse.json(errorResponse, { status: 404 });
+    }
+
+    // 訪問記録での使用チェック
+    const visitRecordsCount = await prisma.visitRecord.count({
+      where: { customerId: id },
+    });
+
+    if (visitRecordsCount > 0) {
+      const errorResponse: ApiErrorResponse = {
+        status: 'error',
+        error: {
+          code: 'RESOURCE_IN_USE',
+          message: '顧客が日報で使用されているため削除できません',
+        },
+      };
+      return NextResponse.json(errorResponse, { status: 400 });
+    }
+
+    // 顧客の削除
+    await prisma.customer.delete({
+      where: { id },
+    });
+
+    return new NextResponse(null, { status: 204 });
+  } catch (error) {
+    console.error('Customer deletion error:', error);
+    const errorResponse: ApiErrorResponse = {
+      status: 'error',
+      error: {
+        code: 'SERVER_ERROR',
+        message: 'サーバーエラーが発生しました',
+      },
+    };
+    return NextResponse.json(errorResponse, { status: 500 });
+  } finally {
+    await prisma.$disconnect();
+  }
+}

--- a/app/api/customers/__tests__/route.test.ts
+++ b/app/api/customers/__tests__/route.test.ts
@@ -1,0 +1,407 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { GET, POST } from '../route';
+import { NextRequest } from 'next/server';
+
+// vi.hoisted を使ってモック関数を定義
+const mockCustomerFindMany = vi.hoisted(() => vi.fn());
+const mockCustomerCount = vi.hoisted(() => vi.fn());
+const mockCustomerFindUnique = vi.hoisted(() => vi.fn());
+const mockCustomerCreate = vi.hoisted(() => vi.fn());
+const mockSalesFindUnique = vi.hoisted(() => vi.fn());
+const mockDisconnect = vi.hoisted(() => vi.fn());
+
+// モックの設定
+vi.mock('@prisma/client', () => {
+  class MockPrismaClient {
+    customer = {
+      findMany: mockCustomerFindMany,
+      count: mockCustomerCount,
+      findUnique: mockCustomerFindUnique,
+      create: mockCustomerCreate,
+    };
+    sales = {
+      findUnique: mockSalesFindUnique,
+    };
+    $disconnect = mockDisconnect;
+  }
+
+  return {
+    PrismaClient: MockPrismaClient,
+  };
+});
+
+vi.mock('@/lib/middleware/auth', () => ({
+  requireAuth: vi.fn(),
+}));
+
+// テスト用のヘルパー関数
+const mockAuth = async () => {
+  const { requireAuth } = await import('@/lib/middleware/auth');
+  vi.mocked(requireAuth).mockResolvedValue({
+    session: {
+      salesId: 'sales-id-1',
+      salesCode: 'S001',
+      salesName: '佐藤花子',
+      email: 'sato@example.com',
+      department: '営業1課',
+      isManager: false,
+      expiresAt: Date.now() + 30 * 60 * 1000,
+    },
+    error: null,
+  } as any);
+};
+
+const mockUnauthorized = async () => {
+  const { requireAuth } = await import('@/lib/middleware/auth');
+  const errorResponse = {
+    status: 'error',
+    error: {
+      code: 'AUTH_UNAUTHORIZED',
+      message: '認証が必要です',
+    },
+  };
+
+  vi.mocked(requireAuth).mockResolvedValue({
+    session: null,
+    error: true,
+    response: {
+      json: () => Promise.resolve(errorResponse),
+      status: 401,
+    } as any,
+  });
+};
+
+describe('GET /api/customers', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('認証済みユーザーは顧客一覧を取得できる', async () => {
+    await mockAuth();
+
+    mockCustomerCount.mockResolvedValue(2);
+    mockCustomerFindMany.mockResolvedValue([
+      {
+        id: 'customer-id-1',
+        customerCode: 'C001',
+        customerName: 'A株式会社',
+        industry: '製造業',
+        postalCode: null,
+        address: '東京都千代田区...',
+        phone: '03-1234-5678',
+        salesId: 'sales-id-1',
+        notes: null,
+        createdAt: new Date('2025-12-01T10:00:00Z'),
+        updatedAt: new Date('2026-01-10T15:00:00Z'),
+        sales: {
+          id: 'sales-id-1',
+          salesName: '佐藤花子',
+        },
+      },
+      {
+        id: 'customer-id-2',
+        customerCode: 'C002',
+        customerName: 'B株式会社',
+        industry: 'IT',
+        postalCode: null,
+        address: '東京都港区...',
+        phone: '03-9876-5432',
+        salesId: 'sales-id-1',
+        notes: null,
+        createdAt: new Date('2025-12-05T10:00:00Z'),
+        updatedAt: new Date('2026-01-12T15:00:00Z'),
+        sales: {
+          id: 'sales-id-1',
+          salesName: '佐藤花子',
+        },
+      },
+    ]);
+
+    const request = new NextRequest('http://localhost/api/customers?page=1&limit=20');
+
+    const response = await GET(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.status).toBe('success');
+    expect(data.data.items).toHaveLength(2);
+    expect(data.data.items[0].customer_code).toBe('C001');
+    expect(data.data.items[0].customer_name).toBe('A株式会社');
+    expect(data.data.items[0].sales.sales_name).toBe('佐藤花子');
+    expect(data.data.pagination.total_items).toBe(2);
+    expect(data.data.pagination.current_page).toBe(1);
+  });
+
+  it('クエリパラメータでフィルタリングできる', async () => {
+    await mockAuth();
+
+    mockCustomerCount.mockResolvedValue(1);
+    mockCustomerFindMany.mockResolvedValue([
+      {
+        id: 'customer-id-1',
+        customerCode: 'C001',
+        customerName: 'A株式会社',
+        industry: '製造業',
+        postalCode: null,
+        address: '東京都千代田区...',
+        phone: '03-1234-5678',
+        salesId: 'sales-id-1',
+        notes: null,
+        createdAt: new Date('2025-12-01T10:00:00Z'),
+        updatedAt: new Date('2026-01-10T15:00:00Z'),
+        sales: {
+          id: 'sales-id-1',
+          salesName: '佐藤花子',
+        },
+      },
+    ]);
+
+    const request = new NextRequest(
+      'http://localhost/api/customers?customer_name=株式会社&customer_code=C001'
+    );
+
+    const response = await GET(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.status).toBe('success');
+    expect(data.data.items).toHaveLength(1);
+    expect(mockCustomerFindMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          customerName: { contains: '株式会社', mode: 'insensitive' },
+          customerCode: { contains: 'C001', mode: 'insensitive' },
+        }),
+      })
+    );
+  });
+
+  it('未認証ユーザーはアクセス拒否される', async () => {
+    await mockUnauthorized();
+
+    const request = new NextRequest('http://localhost/api/customers');
+
+    const response = await GET(request);
+
+    expect(response.status).toBe(401);
+  });
+
+  it('無効なページ番号の場合、バリデーションエラーを返す', async () => {
+    await mockAuth();
+
+    const request = new NextRequest('http://localhost/api/customers?page=0');
+
+    const response = await GET(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(data.status).toBe('error');
+    expect(data.error.code).toBe('VALIDATION_ERROR');
+  });
+});
+
+describe('POST /api/customers', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('認証済みユーザーは顧客を作成できる', async () => {
+    await mockAuth();
+
+    const validSalesId = '507f1f77bcf86cd799439011'; // Valid MongoDB ObjectId
+
+    // 顧客コードが重複していない
+    mockCustomerFindUnique.mockResolvedValueOnce(null);
+    // 営業が存在する
+    mockSalesFindUnique.mockResolvedValueOnce({
+      id: validSalesId,
+      salesCode: 'S001',
+      salesName: '佐藤花子',
+    } as any);
+
+    mockCustomerCreate.mockResolvedValue({
+      id: 'new-customer-id',
+      customerCode: 'C999',
+      customerName: 'テスト株式会社',
+      industry: 'IT',
+      postalCode: '100-0001',
+      address: '東京都千代田区千代田1-1-1',
+      phone: '03-1234-5678',
+      salesId: validSalesId,
+      notes: '新規顧客',
+      createdAt: new Date('2026-01-18T10:00:00Z'),
+      updatedAt: new Date('2026-01-18T10:00:00Z'),
+    });
+
+    const request = new NextRequest('http://localhost/api/customers', {
+      method: 'POST',
+      body: JSON.stringify({
+        customer_code: 'C999',
+        customer_name: 'テスト株式会社',
+        industry: 'IT',
+        postal_code: '100-0001',
+        address: '東京都千代田区千代田1-1-1',
+        phone: '03-1234-5678',
+        sales_id: validSalesId,
+        notes: '新規顧客',
+      }),
+    });
+
+    const response = await POST(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(201);
+    expect(data.status).toBe('success');
+    expect(data.data.customer_code).toBe('C999');
+    expect(data.data.customer_name).toBe('テスト株式会社');
+    expect(mockCustomerCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          customerCode: 'C999',
+          customerName: 'テスト株式会社',
+          industry: 'IT',
+          postalCode: '100-0001',
+          address: '東京都千代田区千代田1-1-1',
+          phone: '03-1234-5678',
+          salesId: validSalesId,
+          notes: '新規顧客',
+        }),
+      })
+    );
+  });
+
+  it('顧客コードが重複している場合、409エラーを返す', async () => {
+    await mockAuth();
+
+    mockCustomerFindUnique.mockResolvedValueOnce({
+      id: 'existing-customer-id',
+      customerCode: 'C001',
+    } as any);
+
+    const request = new NextRequest('http://localhost/api/customers', {
+      method: 'POST',
+      body: JSON.stringify({
+        customer_code: 'C001',
+        customer_name: 'A株式会社',
+        sales_id: '507f1f77bcf86cd799439011',
+      }),
+    });
+
+    const response = await POST(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(409);
+    expect(data.status).toBe('error');
+    expect(data.error.code).toBe('RESOURCE_CONFLICT');
+  });
+
+  it('営業が存在しない場合、400エラーを返す', async () => {
+    await mockAuth();
+
+    const invalidSalesId = '507f1f77bcf86cd799439099';
+
+    // 顧客コードが重複していない
+    mockCustomerFindUnique.mockResolvedValueOnce(null);
+    // 営業が存在しない
+    mockSalesFindUnique.mockResolvedValueOnce(null);
+
+    const request = new NextRequest('http://localhost/api/customers', {
+      method: 'POST',
+      body: JSON.stringify({
+        customer_code: 'C999',
+        customer_name: 'テスト株式会社',
+        sales_id: invalidSalesId,
+      }),
+    });
+
+    const response = await POST(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(data.status).toBe('error');
+    expect(data.error.code).toBe('VALIDATION_ERROR');
+    expect(data.error.details).toEqual([
+      { field: 'sales_id', message: '指定された営業が見つかりません' },
+    ]);
+  });
+
+  it('必須フィールドが不足している場合、バリデーションエラーを返す', async () => {
+    await mockAuth();
+
+    const request = new NextRequest('http://localhost/api/customers', {
+      method: 'POST',
+      body: JSON.stringify({
+        customer_code: 'C999',
+        // customer_name が不足
+        sales_id: '507f1f77bcf86cd799439011',
+      }),
+    });
+
+    const response = await POST(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(data.status).toBe('error');
+    expect(data.error.code).toBe('VALIDATION_ERROR');
+  });
+
+  it('郵便番号の形式が正しくない場合、バリデーションエラーを返す', async () => {
+    await mockAuth();
+
+    const request = new NextRequest('http://localhost/api/customers', {
+      method: 'POST',
+      body: JSON.stringify({
+        customer_code: 'C999',
+        customer_name: 'テスト株式会社',
+        postal_code: '1234567', // 正しくない形式
+        sales_id: '507f1f77bcf86cd799439011',
+      }),
+    });
+
+    const response = await POST(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(data.status).toBe('error');
+    expect(data.error.code).toBe('VALIDATION_ERROR');
+  });
+
+  it('電話番号の形式が正しくない場合、バリデーションエラーを返す', async () => {
+    await mockAuth();
+
+    const request = new NextRequest('http://localhost/api/customers', {
+      method: 'POST',
+      body: JSON.stringify({
+        customer_code: 'C999',
+        customer_name: 'テスト株式会社',
+        phone: '1234567890', // 正しくない形式
+        sales_id: '507f1f77bcf86cd799439011',
+      }),
+    });
+
+    const response = await POST(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(data.status).toBe('error');
+    expect(data.error.code).toBe('VALIDATION_ERROR');
+  });
+
+  it('未認証ユーザーは顧客を作成できない', async () => {
+    await mockUnauthorized();
+
+    const request = new NextRequest('http://localhost/api/customers', {
+      method: 'POST',
+      body: JSON.stringify({
+        customer_code: 'C999',
+        customer_name: 'テスト株式会社',
+        sales_id: '507f1f77bcf86cd799439011',
+      }),
+    });
+
+    const response = await POST(request);
+
+    expect(response.status).toBe(401);
+  });
+});

--- a/app/api/customers/route.ts
+++ b/app/api/customers/route.ts
@@ -1,0 +1,258 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { PrismaClient } from '@prisma/client';
+import { requireAuth } from '@/lib/middleware/auth';
+import {
+  customerListQuerySchema,
+  createCustomerSchema,
+  formatZodErrors,
+} from '@/lib/validations/customer';
+import type { ApiSuccessResponse, ApiErrorResponse } from '@/types/session';
+import type { CustomerListResponse, CustomerCreateResponse } from '@/types/customer';
+
+const prisma = new PrismaClient();
+
+/**
+ * 顧客一覧取得API
+ *
+ * GET /api/customers
+ *
+ * 認証済みユーザーのみアクセス可能
+ * クエリパラメータでフィルタリング・ページネーション可能
+ *
+ * @param request - Next.js Request オブジェクト
+ * @returns 顧客一覧とページネーション情報
+ */
+export async function GET(request: NextRequest) {
+  try {
+    // 認証チェック
+    const authResult = await requireAuth();
+    if (authResult.error) {
+      return authResult.response;
+    }
+
+    // クエリパラメータの取得とバリデーション
+    const { searchParams } = new URL(request.url);
+    const queryParams = {
+      customer_name: searchParams.get('customer_name') || undefined,
+      customer_code: searchParams.get('customer_code') || undefined,
+      sales_id: searchParams.get('sales_id') || undefined,
+      page: searchParams.get('page') || '1',
+      limit: searchParams.get('limit') || '20',
+    };
+
+    const validationResult = customerListQuerySchema.safeParse(queryParams);
+    if (!validationResult.success) {
+      const errorResponse: ApiErrorResponse = {
+        status: 'error',
+        error: {
+          code: 'VALIDATION_ERROR',
+          message: '入力内容に誤りがあります',
+          details: formatZodErrors(validationResult.error),
+        },
+      };
+      return NextResponse.json(errorResponse, { status: 400 });
+    }
+
+    const { customer_name, customer_code, sales_id, page, limit } = validationResult.data;
+
+    // フィルタ条件の構築
+    const where: {
+      customerName?: { contains: string; mode: 'insensitive' };
+      customerCode?: { contains: string; mode: 'insensitive' };
+      salesId?: string;
+    } = {};
+
+    if (customer_name) {
+      where.customerName = { contains: customer_name, mode: 'insensitive' };
+    }
+    if (customer_code) {
+      where.customerCode = { contains: customer_code, mode: 'insensitive' };
+    }
+    if (sales_id) {
+      where.salesId = sales_id;
+    }
+
+    // 総件数の取得
+    const totalItems = await prisma.customer.count({ where });
+
+    // ページネーション計算
+    const totalPages = Math.ceil(totalItems / limit);
+    const skip = (page - 1) * limit;
+
+    // データ取得
+    const customerList = await prisma.customer.findMany({
+      where,
+      skip,
+      take: limit,
+      orderBy: {
+        createdAt: 'desc',
+      },
+      include: {
+        sales: {
+          select: {
+            id: true,
+            salesName: true,
+          },
+        },
+      },
+    });
+
+    // レスポンスの構築
+    const responseData: CustomerListResponse = {
+      items: customerList.map((customer) => ({
+        customer_id: customer.id,
+        customer_code: customer.customerCode,
+        customer_name: customer.customerName,
+        industry: customer.industry ?? undefined,
+        address: customer.address ?? undefined,
+        phone: customer.phone ?? undefined,
+        sales: {
+          sales_id: customer.sales.id,
+          sales_name: customer.sales.salesName,
+        },
+        created_at: customer.createdAt.toISOString(),
+        updated_at: customer.updatedAt.toISOString(),
+      })),
+      pagination: {
+        current_page: page,
+        total_pages: totalPages,
+        total_items: totalItems,
+        limit,
+      },
+    };
+
+    const successResponse: ApiSuccessResponse<CustomerListResponse> = {
+      status: 'success',
+      data: responseData,
+    };
+
+    return NextResponse.json(successResponse, { status: 200 });
+  } catch (error) {
+    console.error('Customer list retrieval error:', error);
+    const errorResponse: ApiErrorResponse = {
+      status: 'error',
+      error: {
+        code: 'SERVER_ERROR',
+        message: 'サーバーエラーが発生しました',
+      },
+    };
+    return NextResponse.json(errorResponse, { status: 500 });
+  } finally {
+    await prisma.$disconnect();
+  }
+}
+
+/**
+ * 顧客作成API
+ *
+ * POST /api/customers
+ *
+ * 認証済みユーザーのみアクセス可能
+ * 顧客コードのユニークチェックを実施
+ *
+ * @param request - Next.js Request オブジェクト
+ * @returns 作成された顧客情報
+ */
+export async function POST(request: NextRequest) {
+  try {
+    // 認証チェック
+    const authResult = await requireAuth();
+    if (authResult.error) {
+      return authResult.response;
+    }
+
+    // リクエストボディの取得
+    const body = await request.json();
+
+    // バリデーション
+    const validationResult = createCustomerSchema.safeParse(body);
+    if (!validationResult.success) {
+      const errorResponse: ApiErrorResponse = {
+        status: 'error',
+        error: {
+          code: 'VALIDATION_ERROR',
+          message: '入力内容に誤りがあります',
+          details: formatZodErrors(validationResult.error),
+        },
+      };
+      return NextResponse.json(errorResponse, { status: 400 });
+    }
+
+    const { customer_code, customer_name, industry, postal_code, address, phone, sales_id, notes } =
+      validationResult.data;
+
+    // 顧客コードの重複チェック
+    const existingCustomer = await prisma.customer.findUnique({
+      where: { customerCode: customer_code },
+    });
+
+    if (existingCustomer) {
+      const errorResponse: ApiErrorResponse = {
+        status: 'error',
+        error: {
+          code: 'RESOURCE_CONFLICT',
+          message: 'この顧客コードは既に使用されています',
+        },
+      };
+      return NextResponse.json(errorResponse, { status: 409 });
+    }
+
+    // 営業IDの存在確認
+    const salesExists = await prisma.sales.findUnique({
+      where: { id: sales_id },
+    });
+
+    if (!salesExists) {
+      const errorResponse: ApiErrorResponse = {
+        status: 'error',
+        error: {
+          code: 'VALIDATION_ERROR',
+          message: '入力内容に誤りがあります',
+          details: [{ field: 'sales_id', message: '指定された営業が見つかりません' }],
+        },
+      };
+      return NextResponse.json(errorResponse, { status: 400 });
+    }
+
+    // 顧客の作成
+    const newCustomer = await prisma.customer.create({
+      data: {
+        customerCode: customer_code,
+        customerName: customer_name,
+        industry: industry ?? null,
+        postalCode: postal_code ?? null,
+        address: address ?? null,
+        phone: phone ?? null,
+        salesId: sales_id,
+        notes: notes ?? null,
+      },
+    });
+
+    // レスポンスの構築
+    const responseData: CustomerCreateResponse = {
+      customer_id: newCustomer.id,
+      customer_code: newCustomer.customerCode,
+      customer_name: newCustomer.customerName,
+      created_at: newCustomer.createdAt.toISOString(),
+    };
+
+    const successResponse: ApiSuccessResponse<CustomerCreateResponse> = {
+      status: 'success',
+      data: responseData,
+    };
+
+    return NextResponse.json(successResponse, { status: 201 });
+  } catch (error) {
+    console.error('Customer creation error:', error);
+    const errorResponse: ApiErrorResponse = {
+      status: 'error',
+      error: {
+        code: 'SERVER_ERROR',
+        message: 'サーバーエラーが発生しました',
+      },
+    };
+    return NextResponse.json(errorResponse, { status: 500 });
+  } finally {
+    await prisma.$disconnect();
+  }
+}

--- a/lib/validations/customer.ts
+++ b/lib/validations/customer.ts
@@ -1,0 +1,121 @@
+import { z } from 'zod';
+
+/**
+ * 顧客コードのバリデーション
+ * - 必須
+ * - 半角英数字のみ
+ * - 最大20文字
+ */
+export const customerCodeSchema = z
+  .string()
+  .min(1, '顧客コードは必須です')
+  .max(20, '顧客コードは20文字以内で入力してください')
+  .regex(/^[a-zA-Z0-9]+$/, '顧客コードは半角英数字で入力してください');
+
+/**
+ * 顧客名のバリデーション
+ * - 必須
+ * - 最大100文字
+ */
+export const customerNameSchema = z
+  .string()
+  .min(1, '顧客名は必須です')
+  .max(100, '顧客名は100文字以内で入力してください');
+
+/**
+ * 業種のバリデーション
+ * - 最大50文字
+ */
+export const industrySchema = z.string().max(50, '業種は50文字以内で入力してください').optional();
+
+/**
+ * 郵便番号のバリデーション
+ * - 郵便番号形式（XXX-XXXX）
+ */
+export const postalCodeSchema = z
+  .string()
+  .regex(/^\d{3}-\d{4}$/, '郵便番号はXXX-XXXX形式で入力してください')
+  .optional();
+
+/**
+ * 住所のバリデーション
+ * - 最大200文字
+ */
+export const addressSchema = z.string().max(200, '住所は200文字以内で入力してください').optional();
+
+/**
+ * 電話番号のバリデーション
+ * - 電話番号形式
+ * - 主な形式: 03-1234-5678, 090-1234-5678, 0120-123-456など
+ */
+export const phoneSchema = z
+  .string()
+  .regex(/^0\d{1,4}-\d{1,4}-\d{4}$/, '電話番号は正しい形式で入力してください（例: 03-1234-5678）')
+  .optional();
+
+/**
+ * 備考のバリデーション
+ * - 最大500文字
+ */
+export const notesSchema = z.string().max(500, '備考は500文字以内で入力してください').optional();
+
+/**
+ * 営業IDのバリデーション（MongoDB ObjectId）
+ * - 24文字の16進数文字列
+ */
+export const salesIdSchema = z.string().regex(/^[0-9a-fA-F]{24}$/, '無効な営業IDです');
+
+/**
+ * 顧客作成リクエストのスキーマ
+ */
+export const createCustomerSchema = z.object({
+  customer_code: customerCodeSchema,
+  customer_name: customerNameSchema,
+  industry: industrySchema,
+  postal_code: postalCodeSchema,
+  address: addressSchema,
+  phone: phoneSchema,
+  sales_id: salesIdSchema,
+  notes: notesSchema,
+});
+
+/**
+ * 顧客更新リクエストのスキーマ
+ * customer_codeは変更不可なので含めない
+ */
+export const updateCustomerSchema = z.object({
+  customer_name: customerNameSchema,
+  industry: industrySchema,
+  postal_code: postalCodeSchema,
+  address: addressSchema,
+  phone: phoneSchema,
+  sales_id: salesIdSchema,
+  notes: notesSchema,
+});
+
+/**
+ * 顧客一覧取得クエリパラメータのスキーマ
+ */
+export const customerListQuerySchema = z.object({
+  customer_name: z.string().optional(),
+  customer_code: z.string().optional(),
+  sales_id: z
+    .string()
+    .regex(/^[0-9a-fA-F]{24}$/, '無効な営業IDです')
+    .optional(),
+  page: z.coerce.number().int().min(1).default(1),
+  limit: z.coerce.number().int().min(1).max(100).default(20),
+});
+
+/**
+ * Zodエラーから詳細なエラーメッセージを抽出する
+ */
+export function formatZodErrors(error: z.ZodError): Array<{ field: string; message: string }> {
+  if (!error || !error.issues || !Array.isArray(error.issues)) {
+    return [];
+  }
+  return error.issues.map((err) => ({
+    field: err.path.join('.'),
+    message: err.message,
+  }));
+}

--- a/types/customer.ts
+++ b/types/customer.ts
@@ -1,0 +1,97 @@
+/**
+ * 顧客マスタAPIのレスポンス型定義
+ */
+
+/**
+ * 顧客情報（基本）
+ */
+export interface CustomerBasic {
+  customer_id: string;
+  customer_code: string;
+  customer_name: string;
+  industry?: string;
+  address?: string;
+  phone?: string;
+  sales: {
+    sales_id: string;
+    sales_name: string;
+  };
+  created_at: string;
+  updated_at: string;
+}
+
+/**
+ * 顧客情報（詳細）
+ */
+export interface CustomerDetail extends CustomerBasic {
+  postal_code?: string;
+  sales: {
+    sales_id: string;
+    sales_name: string;
+    department: string;
+  };
+  notes?: string;
+}
+
+/**
+ * 顧客一覧取得レスポンス
+ */
+export interface CustomerListResponse {
+  items: CustomerBasic[];
+  pagination: {
+    current_page: number;
+    total_pages: number;
+    total_items: number;
+    limit: number;
+  };
+}
+
+/**
+ * 顧客詳細取得レスポンス
+ */
+export type CustomerDetailResponse = CustomerDetail;
+
+/**
+ * 顧客作成レスポンス
+ */
+export interface CustomerCreateResponse {
+  customer_id: string;
+  customer_code: string;
+  customer_name: string;
+  created_at: string;
+}
+
+/**
+ * 顧客更新レスポンス
+ */
+export interface CustomerUpdateResponse {
+  customer_id: string;
+  updated_at: string;
+}
+
+/**
+ * 顧客作成リクエスト
+ */
+export interface CustomerCreateRequest {
+  customer_code: string;
+  customer_name: string;
+  industry?: string;
+  postal_code?: string;
+  address?: string;
+  phone?: string;
+  sales_id: string;
+  notes?: string;
+}
+
+/**
+ * 顧客更新リクエスト
+ */
+export interface CustomerUpdateRequest {
+  customer_name: string;
+  industry?: string;
+  postal_code?: string;
+  address?: string;
+  phone?: string;
+  sales_id: string;
+  notes?: string;
+}


### PR DESCRIPTION
## Summary
Issue #11に基づいて顧客マスタAPIを実装しました。

- GET /api/customers: 顧客一覧取得（ページネーション、検索対応）
- GET /api/customers/:id: 顧客詳細取得
- POST /api/customers: 顧客作成（customer_codeユニークチェック）
- PUT /api/customers/:id: 顧客更新（customer_codeは変更不可）
- DELETE /api/customers/:id: 顧客削除（訪問記録使用中チェック）

## 実装内容

### 新規ファイル
- `lib/validations/customer.ts`: Zodバリデーションスキーマ
- `types/customer.ts`: 顧客関連の型定義
- `app/api/customers/route.ts`: 顧客一覧取得・作成API
- `app/api/customers/[id]/route.ts`: 顧客詳細取得・更新・削除API
- `app/api/customers/__tests__/route.test.ts`: 一覧・作成APIのテスト（11テスト）
- `app/api/customers/[id]/__tests__/route.test.ts`: 詳細・更新・削除APIのテスト（14テスト）

### バリデーション要件（すべて実装済み）
- ✅ customer_code: 必須、半角英数字、ユニーク、最大20文字
- ✅ customer_name: 必須、最大100文字
- ✅ industry: 最大50文字
- ✅ postal_code: 郵便番号形式（XXX-XXXX）
- ✅ address: 最大200文字
- ✅ phone: 電話番号形式
- ✅ sales_id: 必須、有効な営業ID
- ✅ notes: 最大500文字

### データ整合性
- 顧客コードのユニークチェック
- 営業IDの存在確認
- 顧客更新時にcustomer_codeの変更を禁止
- 訪問記録で使用中の顧客は削除不可

## Test plan
- [x] 全25テストが成功
- [x] 型チェックが成功
- [x] Lintが成功
- [x] 既存テスト（450テスト）が全てパス

## 関連Issue
Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)