### PR TITLE
feat: Issue #14 日報APIを実装する

### DIFF
--- a/app/api/reports/[id]/__tests__/route.test.ts
+++ b/app/api/reports/[id]/__tests__/route.test.ts
@@ -1,0 +1,456 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { GET, PUT, DELETE } from '../route';
+import { NextRequest } from 'next/server';
+
+// vi.hoisted を使ってモック関数を定義
+const mockDailyReportFindUnique = vi.hoisted(() => vi.fn());
+const mockDailyReportUpdate = vi.hoisted(() => vi.fn());
+const mockDailyReportDelete = vi.hoisted(() => vi.fn());
+const mockCustomerFindMany = vi.hoisted(() => vi.fn());
+const mockVisitRecordFindMany = vi.hoisted(() => vi.fn());
+const mockVisitRecordDeleteMany = vi.hoisted(() => vi.fn());
+const mockVisitRecordUpdate = vi.hoisted(() => vi.fn());
+const mockVisitRecordCreate = vi.hoisted(() => vi.fn());
+const mockTransaction = vi.hoisted(() => vi.fn());
+const mockDisconnect = vi.hoisted(() => vi.fn());
+
+// モックの設定
+vi.mock('@prisma/client', () => {
+  class MockPrismaClient {
+    dailyReport = {
+      findUnique: mockDailyReportFindUnique,
+      update: mockDailyReportUpdate,
+      delete: mockDailyReportDelete,
+    };
+    customer = {
+      findMany: mockCustomerFindMany,
+    };
+    visitRecord = {
+      findMany: mockVisitRecordFindMany,
+      deleteMany: mockVisitRecordDeleteMany,
+      update: mockVisitRecordUpdate,
+      create: mockVisitRecordCreate,
+    };
+    $transaction = mockTransaction;
+    $disconnect = mockDisconnect;
+  }
+
+  return {
+    PrismaClient: MockPrismaClient,
+  };
+});
+
+vi.mock('@/lib/middleware/auth', () => ({
+  requireAuth: vi.fn(),
+}));
+
+// テスト用のヘルパー関数
+const mockAuth = async (isManager = false) => {
+  const { requireAuth } = await import('@/lib/middleware/auth');
+  vi.mocked(requireAuth).mockResolvedValue({
+    session: {
+      salesId: '507f1f77bcf86cd799439012',
+      salesCode: 'S001',
+      salesName: '佐藤花子',
+      email: 'sato@example.com',
+      department: '営業1課',
+      isManager: isManager,
+      expiresAt: Date.now() + 30 * 60 * 1000,
+    },
+    error: null,
+  } as any);
+};
+
+const _mockUnauthorized = async () => {
+  const { requireAuth } = await import('@/lib/middleware/auth');
+  const errorResponse = {
+    status: 'error',
+    error: {
+      code: 'AUTH_UNAUTHORIZED',
+      message: '認証が必要です',
+    },
+  };
+
+  vi.mocked(requireAuth).mockResolvedValue({
+    session: null,
+    error: true,
+    response: {
+      json: () => Promise.resolve(errorResponse),
+      status: 401,
+    } as any,
+  });
+};
+
+describe('GET /api/reports/[id]', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('営業担当者は自分の日報詳細を取得できる', async () => {
+    await mockAuth(false);
+
+    mockDailyReportFindUnique.mockResolvedValue({
+      id: '507f1f77bcf86cd799439011',
+      salesId: '507f1f77bcf86cd799439012',
+      reportDate: new Date('2026-01-12'),
+      problem: '問題点',
+      plan: '翌日の予定',
+      status: 'SUBMITTED',
+      submittedAt: new Date('2026-01-12T18:00:00Z'),
+      createdAt: new Date('2026-01-12T17:30:00Z'),
+      updatedAt: new Date('2026-01-12T18:00:00Z'),
+      sales: {
+        id: '507f1f77bcf86cd799439012',
+        salesName: '佐藤花子',
+        department: {
+          departmentName: '営業1課',
+        },
+      },
+      visitRecords: [
+        {
+          id: 'visit-id-1',
+          visitDatetime: new Date('2026-01-12T10:00:00Z'),
+          visitContent: '訪問内容1',
+          visitResult: '訪問結果1',
+          displayOrder: 1,
+          customer: {
+            id: 'customer-id-1',
+            customerCode: 'C001',
+            customerName: 'A株式会社',
+          },
+        },
+      ],
+      comments: [
+        {
+          id: 'comment-id-1',
+          commentType: 'PROBLEM',
+          commentText: 'コメント内容',
+          isRead: false,
+          readAt: null,
+          createdAt: new Date('2026-01-12T19:00:00Z'),
+          commenter: {
+            id: 'manager-id-1',
+            salesName: '山田太郎',
+          },
+        },
+      ],
+    });
+
+    const params = Promise.resolve({ id: '507f1f77bcf86cd799439011' });
+    const request = new NextRequest('http://localhost/api/reports/507f1f77bcf86cd799439011');
+
+    const response = await GET(request, { params });
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.status).toBe('success');
+    expect(data.data.report_id).toBe('507f1f77bcf86cd799439011');
+    expect(data.data.visit_records).toHaveLength(1);
+    expect(data.data.comments.problem).toHaveLength(1);
+    expect(data.data.comments.plan).toHaveLength(0);
+  });
+
+  it('管理者は他人の日報詳細を取得できる', async () => {
+    await mockAuth(true);
+
+    mockDailyReportFindUnique.mockResolvedValue({
+      id: '507f1f77bcf86cd799439011',
+      salesId: '507f1f77bcf86cd799439013',
+      reportDate: new Date('2026-01-12'),
+      problem: '問題点',
+      plan: '翌日の予定',
+      status: 'SUBMITTED',
+      submittedAt: new Date('2026-01-12T18:00:00Z'),
+      createdAt: new Date('2026-01-12T17:30:00Z'),
+      updatedAt: new Date('2026-01-12T18:00:00Z'),
+      sales: {
+        id: '507f1f77bcf86cd799439013',
+        salesName: '田中太郎',
+        department: {
+          departmentName: '営業2課',
+        },
+      },
+      visitRecords: [],
+      comments: [],
+    });
+
+    const params = Promise.resolve({ id: '507f1f77bcf86cd799439011' });
+    const request = new NextRequest('http://localhost/api/reports/507f1f77bcf86cd799439011');
+
+    const response = await GET(request, { params });
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.status).toBe('success');
+  });
+
+  it('営業担当者が他人の日報を取得しようとすると403エラー', async () => {
+    await mockAuth(false);
+
+    mockDailyReportFindUnique.mockResolvedValue({
+      id: '507f1f77bcf86cd799439011',
+      salesId: '507f1f77bcf86cd799439013',
+      reportDate: new Date('2026-01-12'),
+      problem: null,
+      plan: null,
+      status: 'DRAFT',
+      submittedAt: null,
+      createdAt: new Date('2026-01-12T17:30:00Z'),
+      updatedAt: new Date('2026-01-12T17:30:00Z'),
+      sales: {
+        id: '507f1f77bcf86cd799439013',
+        salesName: '田中太郎',
+        department: {
+          departmentName: '営業2課',
+        },
+      },
+      visitRecords: [],
+      comments: [],
+    });
+
+    const params = Promise.resolve({ id: '507f1f77bcf86cd799439011' });
+    const request = new NextRequest('http://localhost/api/reports/507f1f77bcf86cd799439011');
+
+    const response = await GET(request, { params });
+    const data = await response.json();
+
+    expect(response.status).toBe(403);
+    expect(data.status).toBe('error');
+    expect(data.error.code).toBe('AUTH_FORBIDDEN');
+  });
+
+  it('存在しない日報IDの場合は404エラー', async () => {
+    await mockAuth(false);
+
+    mockDailyReportFindUnique.mockResolvedValue(null);
+
+    const params = Promise.resolve({ id: '000000000000000000000000' });
+    const request = new NextRequest('http://localhost/api/reports/000000000000000000000000');
+
+    const response = await GET(request, { params });
+    const data = await response.json();
+
+    expect(response.status).toBe(404);
+    expect(data.status).toBe('error');
+    expect(data.error.code).toBe('RESOURCE_NOT_FOUND');
+  });
+
+  it('無効な日報IDの場合は400エラー', async () => {
+    await mockAuth(false);
+
+    const params = Promise.resolve({ id: 'invalid-id' });
+    const request = new NextRequest('http://localhost/api/reports/invalid-id');
+
+    const response = await GET(request, { params });
+    const data = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(data.status).toBe('error');
+    expect(data.error.code).toBe('VALIDATION_ERROR');
+  });
+});
+
+describe('PUT /api/reports/[id]', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('日報を更新できる', async () => {
+    await mockAuth(false);
+
+    mockDailyReportFindUnique.mockResolvedValue({
+      id: '507f1f77bcf86cd799439011',
+      salesId: '507f1f77bcf86cd799439012',
+      status: 'DRAFT',
+      submittedAt: null,
+      visitRecords: [{ id: '507f1f77bcf86cd799439014' }],
+    });
+
+    mockCustomerFindMany.mockResolvedValue([{ id: '507f1f77bcf86cd799439015' }]);
+    mockVisitRecordFindMany.mockResolvedValue([{ id: '507f1f77bcf86cd799439014' }]);
+
+    const mockUpdatedReport = {
+      id: '507f1f77bcf86cd799439011',
+      updatedAt: new Date('2026-01-12T19:00:00Z'),
+    };
+
+    mockTransaction.mockImplementation(async (callback: any) => {
+      return await callback({
+        dailyReport: {
+          update: mockDailyReportUpdate.mockResolvedValue(mockUpdatedReport),
+        },
+        visitRecord: {
+          deleteMany: mockVisitRecordDeleteMany.mockResolvedValue({ count: 0 }),
+          update: mockVisitRecordUpdate.mockResolvedValue({}),
+          create: mockVisitRecordCreate.mockResolvedValue({}),
+        },
+      });
+    });
+
+    const requestBody = {
+      problem: '更新された問題点',
+      plan: '更新された予定',
+      status: 'submitted',
+      visit_records: [
+        {
+          visit_id: '507f1f77bcf86cd799439014',
+          customer_id: '507f1f77bcf86cd799439015',
+          visit_datetime: '2026-01-12T10:00:00.000Z',
+          visit_content: '更新された訪問内容',
+          visit_result: '更新された訪問結果',
+          display_order: 1,
+        },
+      ],
+    };
+
+    const params = Promise.resolve({ id: '507f1f77bcf86cd799439011' });
+    const request = new NextRequest('http://localhost/api/reports/507f1f77bcf86cd799439011', {
+      method: 'PUT',
+      body: JSON.stringify(requestBody),
+    });
+
+    const response = await PUT(request, { params });
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.status).toBe('success');
+    expect(data.data.report_id).toBe('507f1f77bcf86cd799439011');
+  });
+
+  it('他人の日報を更新しようとすると403エラー', async () => {
+    await mockAuth(false);
+
+    mockDailyReportFindUnique.mockResolvedValue({
+      id: '507f1f77bcf86cd799439011',
+      salesId: '507f1f77bcf86cd799439013',
+      status: 'DRAFT',
+      submittedAt: null,
+      visitRecords: [],
+    });
+
+    const requestBody = {
+      problem: '更新された問題点',
+      status: 'draft',
+      visit_records: [
+        {
+          customer_id: '507f1f77bcf86cd799439015',
+          visit_datetime: '2026-01-12T10:00:00.000Z',
+          visit_content: '訪問内容',
+          display_order: 1,
+        },
+      ],
+    };
+
+    const params = Promise.resolve({ id: '507f1f77bcf86cd799439011' });
+    const request = new NextRequest('http://localhost/api/reports/507f1f77bcf86cd799439011', {
+      method: 'PUT',
+      body: JSON.stringify(requestBody),
+    });
+
+    const response = await PUT(request, { params });
+    const data = await response.json();
+
+    expect(response.status).toBe(403);
+    expect(data.status).toBe('error');
+    expect(data.error.code).toBe('AUTH_FORBIDDEN');
+  });
+
+  it('存在しない日報IDの場合は404エラー', async () => {
+    await mockAuth(false);
+
+    mockDailyReportFindUnique.mockResolvedValue(null);
+
+    const requestBody = {
+      status: 'draft',
+      visit_records: [
+        {
+          customer_id: '507f1f77bcf86cd799439015',
+          visit_datetime: '2026-01-12T10:00:00.000Z',
+          visit_content: '訪問内容',
+          display_order: 1,
+        },
+      ],
+    };
+
+    const params = Promise.resolve({ id: '000000000000000000000000' });
+    const request = new NextRequest('http://localhost/api/reports/000000000000000000000000', {
+      method: 'PUT',
+      body: JSON.stringify(requestBody),
+    });
+
+    const response = await PUT(request, { params });
+    const data = await response.json();
+
+    expect(response.status).toBe(404);
+    expect(data.status).toBe('error');
+    expect(data.error.code).toBe('RESOURCE_NOT_FOUND');
+  });
+});
+
+describe('DELETE /api/reports/[id]', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('日報を削除できる', async () => {
+    await mockAuth(false);
+
+    mockDailyReportFindUnique.mockResolvedValue({
+      id: '507f1f77bcf86cd799439011',
+      salesId: '507f1f77bcf86cd799439012',
+    });
+
+    mockDailyReportDelete.mockResolvedValue({
+      id: '507f1f77bcf86cd799439011',
+    });
+
+    const params = Promise.resolve({ id: '507f1f77bcf86cd799439011' });
+    const request = new NextRequest('http://localhost/api/reports/507f1f77bcf86cd799439011', {
+      method: 'DELETE',
+    });
+
+    const response = await DELETE(request, { params });
+
+    expect(response.status).toBe(204);
+  });
+
+  it('他人の日報を削除しようとすると403エラー', async () => {
+    await mockAuth(false);
+
+    mockDailyReportFindUnique.mockResolvedValue({
+      id: '507f1f77bcf86cd799439011',
+      salesId: '507f1f77bcf86cd799439013',
+    });
+
+    const params = Promise.resolve({ id: '507f1f77bcf86cd799439011' });
+    const request = new NextRequest('http://localhost/api/reports/507f1f77bcf86cd799439011', {
+      method: 'DELETE',
+    });
+
+    const response = await DELETE(request, { params });
+    const data = await response.json();
+
+    expect(response.status).toBe(403);
+    expect(data.status).toBe('error');
+    expect(data.error.code).toBe('AUTH_FORBIDDEN');
+  });
+
+  it('存在しない日報IDの場合は404エラー', async () => {
+    await mockAuth(false);
+
+    mockDailyReportFindUnique.mockResolvedValue(null);
+
+    const params = Promise.resolve({ id: '000000000000000000000000' });
+    const request = new NextRequest('http://localhost/api/reports/000000000000000000000000', {
+      method: 'DELETE',
+    });
+
+    const response = await DELETE(request, { params });
+    const data = await response.json();
+
+    expect(response.status).toBe(404);
+    expect(data.status).toBe('error');
+    expect(data.error.code).toBe('RESOURCE_NOT_FOUND');
+  });
+});

--- a/app/api/reports/[id]/route.ts
+++ b/app/api/reports/[id]/route.ts
@@ -1,0 +1,544 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { PrismaClient } from '@prisma/client';
+import { requireAuth } from '@/lib/middleware/auth';
+import { updateReportSchema, formatZodErrors } from '@/lib/validations/report';
+import type { ApiSuccessResponse, ApiErrorResponse } from '@/types/session';
+import type { ReportDetailResponse, ReportUpdateResponse } from '@/types/report';
+
+const prisma = new PrismaClient();
+
+/**
+ * 日報詳細取得API
+ *
+ * GET /api/reports/:id
+ *
+ * 認証済みユーザーのみアクセス可能
+ * 管理者は全員分、営業担当者は自分の日報のみ取得可能
+ *
+ * @param request - Next.js Request オブジェクト
+ * @param params - パスパラメータ
+ * @returns 日報詳細情報
+ */
+export async function GET(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  try {
+    // 認証チェック
+    const authResult = await requireAuth();
+    if (authResult.error) {
+      return authResult.response;
+    }
+    const session = authResult.session;
+
+    const { id } = await params;
+
+    // 日報IDのバリデーション（MongoDB ObjectId）
+    if (!/^[0-9a-fA-F]{24}$/.test(id)) {
+      const errorResponse: ApiErrorResponse = {
+        status: 'error',
+        error: {
+          code: 'VALIDATION_ERROR',
+          message: '無効な日報IDです',
+        },
+      };
+      return NextResponse.json(errorResponse, { status: 400 });
+    }
+
+    // 日報データの取得
+    const report = await prisma.dailyReport.findUnique({
+      where: { id },
+      include: {
+        sales: {
+          select: {
+            id: true,
+            salesName: true,
+            department: {
+              select: {
+                departmentName: true,
+              },
+            },
+          },
+        },
+        visitRecords: {
+          include: {
+            customer: {
+              select: {
+                id: true,
+                customerCode: true,
+                customerName: true,
+              },
+            },
+          },
+          orderBy: {
+            displayOrder: 'asc',
+          },
+        },
+        comments: {
+          include: {
+            commenter: {
+              select: {
+                id: true,
+                salesName: true,
+              },
+            },
+          },
+          orderBy: {
+            createdAt: 'asc',
+          },
+        },
+      },
+    });
+
+    if (!report) {
+      const errorResponse: ApiErrorResponse = {
+        status: 'error',
+        error: {
+          code: 'RESOURCE_NOT_FOUND',
+          message: '日報が見つかりません',
+        },
+      };
+      return NextResponse.json(errorResponse, { status: 404 });
+    }
+
+    // 権限チェック: 営業担当者は自分の日報のみ、管理者は全員分
+    if (!session.isManager && report.salesId !== session.salesId) {
+      const errorResponse: ApiErrorResponse = {
+        status: 'error',
+        error: {
+          code: 'AUTH_FORBIDDEN',
+          message: '権限がありません',
+        },
+      };
+      return NextResponse.json(errorResponse, { status: 403 });
+    }
+
+    // ステータスマップ
+    const statusMap: Record<string, 'draft' | 'submitted' | 'commented'> = {
+      DRAFT: 'draft',
+      SUBMITTED: 'submitted',
+      COMMENTED: 'commented',
+    };
+
+    // コメントを問題点・翌日の予定別に分類
+    const problemComments = report.comments
+      .filter((c) => c.commentType === 'PROBLEM')
+      .map((c) => ({
+        comment_id: c.id,
+        commenter: {
+          sales_id: c.commenter.id,
+          sales_name: c.commenter.salesName,
+        },
+        comment_text: c.commentText,
+        is_read: c.isRead,
+        read_at: c.readAt?.toISOString(),
+        created_at: c.createdAt.toISOString(),
+      }));
+
+    const planComments = report.comments
+      .filter((c) => c.commentType === 'PLAN')
+      .map((c) => ({
+        comment_id: c.id,
+        commenter: {
+          sales_id: c.commenter.id,
+          sales_name: c.commenter.salesName,
+        },
+        comment_text: c.commentText,
+        is_read: c.isRead,
+        read_at: c.readAt?.toISOString(),
+        created_at: c.createdAt.toISOString(),
+      }));
+
+    // レスポンスの構築
+    const responseData: ReportDetailResponse = {
+      report_id: report.id,
+      report_date: report.reportDate.toISOString().split('T')[0],
+      sales: {
+        sales_id: report.sales.id,
+        sales_name: report.sales.salesName,
+        department: report.sales.department.departmentName,
+      },
+      problem: report.problem ?? undefined,
+      plan: report.plan ?? undefined,
+      status: statusMap[report.status] || 'draft',
+      submitted_at: report.submittedAt?.toISOString(),
+      visit_records: report.visitRecords.map((record) => ({
+        visit_id: record.id,
+        customer: {
+          customer_id: record.customer.id,
+          customer_code: record.customer.customerCode,
+          customer_name: record.customer.customerName,
+        },
+        visit_datetime: record.visitDatetime.toISOString(),
+        visit_content: record.visitContent,
+        visit_result: record.visitResult ?? undefined,
+        display_order: record.displayOrder,
+      })),
+      comments: {
+        problem: problemComments,
+        plan: planComments,
+      },
+      created_at: report.createdAt.toISOString(),
+      updated_at: report.updatedAt.toISOString(),
+    };
+
+    const successResponse: ApiSuccessResponse<ReportDetailResponse> = {
+      status: 'success',
+      data: responseData,
+    };
+
+    return NextResponse.json(successResponse, { status: 200 });
+  } catch (error) {
+    console.error('Report detail retrieval error:', error);
+    const errorResponse: ApiErrorResponse = {
+      status: 'error',
+      error: {
+        code: 'SERVER_ERROR',
+        message: 'サーバーエラーが発生しました',
+      },
+    };
+    return NextResponse.json(errorResponse, { status: 500 });
+  } finally {
+    await prisma.$disconnect();
+  }
+}
+
+/**
+ * 日報更新API
+ *
+ * PUT /api/reports/:id
+ *
+ * 認証済みユーザーのみアクセス可能
+ * 営業担当者は自分の日報のみ更新可能
+ * 訪問記録の差分更新（visit_idあり: 更新、なし: 新規作成、リクエストに含まれない: 削除）
+ *
+ * @param request - Next.js Request オブジェクト
+ * @param params - パスパラメータ
+ * @returns 更新された日報情報
+ */
+export async function PUT(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  try {
+    // 認証チェック
+    const authResult = await requireAuth();
+    if (authResult.error) {
+      return authResult.response;
+    }
+    const session = authResult.session;
+
+    const { id } = await params;
+
+    // 日報IDのバリデーション（MongoDB ObjectId）
+    if (!/^[0-9a-fA-F]{24}$/.test(id)) {
+      const errorResponse: ApiErrorResponse = {
+        status: 'error',
+        error: {
+          code: 'VALIDATION_ERROR',
+          message: '無効な日報IDです',
+        },
+      };
+      return NextResponse.json(errorResponse, { status: 400 });
+    }
+
+    // 日報の存在確認
+    const existingReport = await prisma.dailyReport.findUnique({
+      where: { id },
+      include: {
+        visitRecords: {
+          select: {
+            id: true,
+          },
+        },
+      },
+    });
+
+    if (!existingReport) {
+      const errorResponse: ApiErrorResponse = {
+        status: 'error',
+        error: {
+          code: 'RESOURCE_NOT_FOUND',
+          message: '日報が見つかりません',
+        },
+      };
+      return NextResponse.json(errorResponse, { status: 404 });
+    }
+
+    // 権限チェック: 営業担当者は自分の日報のみ更新可能
+    if (existingReport.salesId !== session.salesId) {
+      const errorResponse: ApiErrorResponse = {
+        status: 'error',
+        error: {
+          code: 'AUTH_FORBIDDEN',
+          message: '権限がありません',
+        },
+      };
+      return NextResponse.json(errorResponse, { status: 403 });
+    }
+
+    // リクエストボディの取得
+    const body = await request.json();
+
+    // バリデーション
+    const validationResult = updateReportSchema.safeParse(body);
+    if (!validationResult.success) {
+      const errorResponse: ApiErrorResponse = {
+        status: 'error',
+        error: {
+          code: 'VALIDATION_ERROR',
+          message: '入力内容に誤りがあります',
+          details: formatZodErrors(validationResult.error),
+        },
+      };
+      return NextResponse.json(errorResponse, { status: 400 });
+    }
+
+    const { problem, plan, status, visit_records } = validationResult.data;
+
+    // 顧客IDの存在確認
+    const customerIds = visit_records.map((record) => record.customer_id);
+    const customers = await prisma.customer.findMany({
+      where: {
+        id: {
+          in: customerIds,
+        },
+      },
+      select: {
+        id: true,
+      },
+    });
+
+    const foundCustomerIds = new Set(customers.map((c) => c.id));
+    const invalidCustomerIds = customerIds.filter((id) => !foundCustomerIds.has(id));
+
+    if (invalidCustomerIds.length > 0) {
+      const errorResponse: ApiErrorResponse = {
+        status: 'error',
+        error: {
+          code: 'VALIDATION_ERROR',
+          message: '入力内容に誤りがあります',
+          details: invalidCustomerIds.map((id) => ({
+            field: 'visit_records.customer_id',
+            message: `指定された顧客が見つかりません: ${id}`,
+          })),
+        },
+      };
+      return NextResponse.json(errorResponse, { status: 400 });
+    }
+
+    // 訪問記録IDのバリデーション
+    const visitIdsToUpdate = visit_records.filter((r) => r.visit_id).map((r) => r.visit_id!);
+    if (visitIdsToUpdate.length > 0) {
+      const existingVisitRecords = await prisma.visitRecord.findMany({
+        where: {
+          id: {
+            in: visitIdsToUpdate,
+          },
+          reportId: id,
+        },
+        select: {
+          id: true,
+        },
+      });
+
+      const foundVisitIds = new Set(existingVisitRecords.map((v) => v.id));
+      const invalidVisitIds = visitIdsToUpdate.filter((vid) => !foundVisitIds.has(vid));
+
+      if (invalidVisitIds.length > 0) {
+        const errorResponse: ApiErrorResponse = {
+          status: 'error',
+          error: {
+            code: 'VALIDATION_ERROR',
+            message: '入力内容に誤りがあります',
+            details: invalidVisitIds.map((vid) => ({
+              field: 'visit_records.visit_id',
+              message: `指定された訪問記録が見つかりません: ${vid}`,
+            })),
+          },
+        };
+        return NextResponse.json(errorResponse, { status: 400 });
+      }
+    }
+
+    // ステータスマップ
+    const statusMap: Record<string, string> = {
+      draft: 'DRAFT',
+      submitted: 'SUBMITTED',
+    };
+
+    // 日報と訪問記録の更新（トランザクション）
+    const updatedReport = await prisma.$transaction(async (tx) => {
+      // 日報更新
+      const report = await tx.dailyReport.update({
+        where: { id },
+        data: {
+          problem: problem ?? null,
+          plan: plan ?? null,
+          status: (statusMap[status] as 'DRAFT' | 'SUBMITTED') || 'DRAFT',
+          submittedAt:
+            status === 'submitted' && existingReport.status !== 'SUBMITTED'
+              ? new Date()
+              : existingReport.submittedAt,
+        },
+      });
+
+      // 既存の訪問記録IDを取得
+      const existingVisitIds = new Set(existingReport.visitRecords.map((v) => v.id));
+      const requestVisitIds = new Set(
+        visit_records.filter((r) => r.visit_id).map((r) => r.visit_id!)
+      );
+
+      // 削除する訪問記録（リクエストに含まれない既存の記録）
+      const visitIdsToDelete = Array.from(existingVisitIds).filter(
+        (vid) => !requestVisitIds.has(vid)
+      );
+      if (visitIdsToDelete.length > 0) {
+        await tx.visitRecord.deleteMany({
+          where: {
+            id: {
+              in: visitIdsToDelete,
+            },
+          },
+        });
+      }
+
+      // 訪問記録の更新と作成
+      for (const record of visit_records) {
+        if (record.visit_id) {
+          // 既存レコードの更新
+          await tx.visitRecord.update({
+            where: { id: record.visit_id },
+            data: {
+              customerId: record.customer_id,
+              visitDatetime: new Date(record.visit_datetime),
+              visitContent: record.visit_content,
+              visitResult: record.visit_result ?? null,
+              displayOrder: record.display_order,
+            },
+          });
+        } else {
+          // 新規レコードの作成
+          await tx.visitRecord.create({
+            data: {
+              reportId: id,
+              customerId: record.customer_id,
+              visitDatetime: new Date(record.visit_datetime),
+              visitContent: record.visit_content,
+              visitResult: record.visit_result ?? null,
+              displayOrder: record.display_order,
+            },
+          });
+        }
+      }
+
+      return report;
+    });
+
+    // レスポンスの構築
+    const responseData: ReportUpdateResponse = {
+      report_id: updatedReport.id,
+      updated_at: updatedReport.updatedAt.toISOString(),
+    };
+
+    const successResponse: ApiSuccessResponse<ReportUpdateResponse> = {
+      status: 'success',
+      data: responseData,
+    };
+
+    return NextResponse.json(successResponse, { status: 200 });
+  } catch (error) {
+    console.error('Report update error:', error);
+    const errorResponse: ApiErrorResponse = {
+      status: 'error',
+      error: {
+        code: 'SERVER_ERROR',
+        message: 'サーバーエラーが発生しました',
+      },
+    };
+    return NextResponse.json(errorResponse, { status: 500 });
+  } finally {
+    await prisma.$disconnect();
+  }
+}
+
+/**
+ * 日報削除API
+ *
+ * DELETE /api/reports/:id
+ *
+ * 認証済みユーザーのみアクセス可能
+ * 営業担当者は自分の日報のみ削除可能
+ *
+ * @param request - Next.js Request オブジェクト
+ * @param params - パスパラメータ
+ * @returns 削除成功時は204 No Content
+ */
+export async function DELETE(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    // 認証チェック
+    const authResult = await requireAuth();
+    if (authResult.error) {
+      return authResult.response;
+    }
+    const session = authResult.session;
+
+    const { id } = await params;
+
+    // 日報IDのバリデーション（MongoDB ObjectId）
+    if (!/^[0-9a-fA-F]{24}$/.test(id)) {
+      const errorResponse: ApiErrorResponse = {
+        status: 'error',
+        error: {
+          code: 'VALIDATION_ERROR',
+          message: '無効な日報IDです',
+        },
+      };
+      return NextResponse.json(errorResponse, { status: 400 });
+    }
+
+    // 日報の存在確認
+    const existingReport = await prisma.dailyReport.findUnique({
+      where: { id },
+    });
+
+    if (!existingReport) {
+      const errorResponse: ApiErrorResponse = {
+        status: 'error',
+        error: {
+          code: 'RESOURCE_NOT_FOUND',
+          message: '日報が見つかりません',
+        },
+      };
+      return NextResponse.json(errorResponse, { status: 404 });
+    }
+
+    // 権限チェック: 営業担当者は自分の日報のみ削除可能
+    if (existingReport.salesId !== session.salesId) {
+      const errorResponse: ApiErrorResponse = {
+        status: 'error',
+        error: {
+          code: 'AUTH_FORBIDDEN',
+          message: '権限がありません',
+        },
+      };
+      return NextResponse.json(errorResponse, { status: 403 });
+    }
+
+    // 日報の削除（訪問記録とコメントはCascade削除される）
+    await prisma.dailyReport.delete({
+      where: { id },
+    });
+
+    return new NextResponse(null, { status: 204 });
+  } catch (error) {
+    console.error('Report deletion error:', error);
+    const errorResponse: ApiErrorResponse = {
+      status: 'error',
+      error: {
+        code: 'SERVER_ERROR',
+        message: 'サーバーエラーが発生しました',
+      },
+    };
+    return NextResponse.json(errorResponse, { status: 500 });
+  } finally {
+    await prisma.$disconnect();
+  }
+}

--- a/app/api/reports/__tests__/route.test.ts
+++ b/app/api/reports/__tests__/route.test.ts
@@ -238,16 +238,125 @@ describe('GET /api/reports', () => {
     const response = await GET(request);
 
     expect(response.status).toBe(200);
-    expect(mockDailyReportFindMany).toHaveBeenCalledWith(
-      expect.objectContaining({
-        where: expect.objectContaining({
-          reportDate: expect.objectContaining({
-            gte: expect.any(Date),
-            lte: expect.any(Date),
-          }),
-        }),
-      })
-    );
+
+    // 日付範囲がパラメータ通りに設定されているか確認
+    const callArgs = mockDailyReportFindMany.mock.calls[0][0];
+    expect(callArgs.where.reportDate.gte).toEqual(new Date('2026-01-01'));
+    // end_dateは当日の23:59:59まで含めるため、ローカルタイムで設定される
+    const expectedEndDate = new Date('2026-01-31');
+    expectedEndDate.setHours(23, 59, 59, 999);
+    expect(callArgs.where.reportDate.lte).toEqual(expectedEndDate);
+  });
+
+  it('マネージャーは他人のdraft日報を取得できない', async () => {
+    await mockAuth(true); // マネージャーとしてログイン
+
+    const mockReports = [
+      {
+        id: 'report-1',
+        salesId: 'other-sales-id', // 他人の日報
+        reportDate: new Date('2026-01-15'),
+        status: 'DRAFT',
+        sales: { id: 'other-sales-id', salesName: '他の営業担当' },
+        visitRecords: [],
+        comments: [],
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+      {
+        id: 'report-2',
+        salesId: 'other-sales-id',
+        reportDate: new Date('2026-01-16'),
+        status: 'SUBMITTED',
+        submittedAt: new Date(),
+        sales: { id: 'other-sales-id', salesName: '他の営業担当' },
+        visitRecords: [],
+        comments: [],
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+    ];
+
+    mockDailyReportCount.mockResolvedValue(2);
+    mockDailyReportFindMany.mockResolvedValue(mockReports);
+
+    const url = new URL('http://localhost/api/reports');
+    const request = new NextRequest(url);
+    const response = await GET(request);
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+
+    // draftは除外され、submittedのみが返される
+    expect(data.data.items).toHaveLength(1);
+    expect(data.data.items[0].status).toBe('submitted');
+  });
+
+  it('マネージャーは自分のdraft日報は取得できる', async () => {
+    await mockAuth(true); // マネージャーとしてログイン
+
+    const mockReports = [
+      {
+        id: 'report-1',
+        salesId: '507f1f77bcf86cd799439012', // 自分の日報
+        reportDate: new Date('2026-01-15'),
+        status: 'DRAFT',
+        sales: { id: '507f1f77bcf86cd799439012', salesName: 'テスト営業' },
+        visitRecords: [],
+        comments: [],
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+    ];
+
+    mockDailyReportCount.mockResolvedValue(1);
+    mockDailyReportFindMany.mockResolvedValue(mockReports);
+
+    const url = new URL('http://localhost/api/reports');
+    const request = new NextRequest(url);
+    const response = await GET(request);
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+
+    // 自分のdraftは表示される
+    expect(data.data.items).toHaveLength(1);
+    expect(data.data.items[0].status).toBe('draft');
+  });
+
+  it('未読コメント数は本人以外が書いたコメントのみカウントする', async () => {
+    await mockAuth(false);
+
+    const mockReports = [
+      {
+        id: 'report-1',
+        salesId: '507f1f77bcf86cd799439012',
+        reportDate: new Date('2026-01-15'),
+        status: 'COMMENTED',
+        sales: { id: '507f1f77bcf86cd799439012', salesName: 'テスト営業' },
+        visitRecords: [],
+        comments: [
+          { id: 'comment-1', isRead: false, commenterId: '507f1f77bcf86cd799439012' }, // 本人のコメント
+          { id: 'comment-2', isRead: false, commenterId: 'manager-id' }, // 他人のコメント
+          { id: 'comment-3', isRead: true, commenterId: 'manager-id' }, // 既読
+        ],
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+    ];
+
+    mockDailyReportCount.mockResolvedValue(1);
+    mockDailyReportFindMany.mockResolvedValue(mockReports);
+
+    const url = new URL('http://localhost/api/reports');
+    const request = new NextRequest(url);
+    const response = await GET(request);
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+
+    // 未読コメント数は1（本人以外の未読コメントのみ）
+    expect(data.data.items[0].unread_comment_count).toBe(1);
   });
 });
 

--- a/app/api/reports/__tests__/route.test.ts
+++ b/app/api/reports/__tests__/route.test.ts
@@ -1,0 +1,444 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { GET, POST } from '../route';
+import { NextRequest } from 'next/server';
+
+// vi.hoisted を使ってモック関数を定義
+const mockDailyReportFindMany = vi.hoisted(() => vi.fn());
+const mockDailyReportCount = vi.hoisted(() => vi.fn());
+const mockDailyReportFindFirst = vi.hoisted(() => vi.fn());
+const mockDailyReportCreate = vi.hoisted(() => vi.fn());
+const mockCustomerFindMany = vi.hoisted(() => vi.fn());
+const mockVisitRecordCreateMany = vi.hoisted(() => vi.fn());
+const mockTransaction = vi.hoisted(() => vi.fn());
+const mockDisconnect = vi.hoisted(() => vi.fn());
+
+// モックの設定
+vi.mock('@prisma/client', () => {
+  class MockPrismaClient {
+    dailyReport = {
+      findMany: mockDailyReportFindMany,
+      count: mockDailyReportCount,
+      findFirst: mockDailyReportFindFirst,
+      create: mockDailyReportCreate,
+    };
+    customer = {
+      findMany: mockCustomerFindMany,
+    };
+    visitRecord = {
+      createMany: mockVisitRecordCreateMany,
+    };
+    $transaction = mockTransaction;
+    $disconnect = mockDisconnect;
+  }
+
+  return {
+    PrismaClient: MockPrismaClient,
+    Prisma: {
+      DailyReportWhereInput: {},
+    },
+  };
+});
+
+vi.mock('@/lib/middleware/auth', () => ({
+  requireAuth: vi.fn(),
+}));
+
+// テスト用のヘルパー関数
+const mockAuth = async (isManager = false) => {
+  const { requireAuth } = await import('@/lib/middleware/auth');
+  vi.mocked(requireAuth).mockResolvedValue({
+    session: {
+      salesId: '507f1f77bcf86cd799439012',
+      salesCode: 'S001',
+      salesName: '佐藤花子',
+      email: 'sato@example.com',
+      department: '営業1課',
+      isManager: isManager,
+      expiresAt: Date.now() + 30 * 60 * 1000,
+    },
+    error: null,
+  } as any);
+};
+
+const mockUnauthorized = async () => {
+  const { requireAuth } = await import('@/lib/middleware/auth');
+  const errorResponse = {
+    status: 'error',
+    error: {
+      code: 'AUTH_UNAUTHORIZED',
+      message: '認証が必要です',
+    },
+  };
+
+  vi.mocked(requireAuth).mockResolvedValue({
+    session: null,
+    error: true,
+    response: {
+      json: () => Promise.resolve(errorResponse),
+      status: 401,
+    } as any,
+  });
+};
+
+describe('GET /api/reports', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('営業担当者は自分の日報一覧を取得できる', async () => {
+    await mockAuth(false);
+
+    mockDailyReportCount.mockResolvedValue(2);
+    mockDailyReportFindMany.mockResolvedValue([
+      {
+        id: 'report-id-1',
+        salesId: 'sales-id-1',
+        reportDate: new Date('2026-01-12'),
+        problem: '問題点',
+        plan: '翌日の予定',
+        status: 'SUBMITTED',
+        submittedAt: new Date('2026-01-12T18:00:00Z'),
+        createdAt: new Date('2026-01-12T17:30:00Z'),
+        updatedAt: new Date('2026-01-12T18:00:00Z'),
+        sales: {
+          id: 'sales-id-1',
+          salesName: '佐藤花子',
+        },
+        visitRecords: [{ id: 'visit-id-1' }, { id: 'visit-id-2' }],
+        comments: [
+          {
+            id: 'comment-id-1',
+            isRead: false,
+            dailyReport: { salesId: 'sales-id-1' },
+          },
+        ],
+      },
+      {
+        id: 'report-id-2',
+        salesId: 'sales-id-1',
+        reportDate: new Date('2026-01-11'),
+        problem: null,
+        plan: null,
+        status: 'DRAFT',
+        submittedAt: null,
+        createdAt: new Date('2026-01-11T17:30:00Z'),
+        updatedAt: new Date('2026-01-11T17:30:00Z'),
+        sales: {
+          id: 'sales-id-1',
+          salesName: '佐藤花子',
+        },
+        visitRecords: [{ id: 'visit-id-3' }],
+        comments: [],
+      },
+    ]);
+
+    const url = new URL('http://localhost/api/reports?page=1&limit=20');
+    const request = new NextRequest(url);
+
+    const response = await GET(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.status).toBe('success');
+    expect(data.data.items).toHaveLength(2);
+    expect(data.data.items[0].report_id).toBe('report-id-1');
+    expect(data.data.items[0].visit_count).toBe(2);
+    expect(data.data.items[0].status).toBe('submitted');
+    expect(data.data.items[0].unread_comment_count).toBe(1);
+    expect(data.data.pagination.total_items).toBe(2);
+  });
+
+  it('管理者は全員分の日報一覧を取得できる', async () => {
+    await mockAuth(true);
+
+    mockDailyReportCount.mockResolvedValue(1);
+    mockDailyReportFindMany.mockResolvedValue([
+      {
+        id: 'report-id-1',
+        salesId: 'sales-id-2',
+        reportDate: new Date('2026-01-12'),
+        problem: '問題点',
+        plan: '翌日の予定',
+        status: 'SUBMITTED',
+        submittedAt: new Date('2026-01-12T18:00:00Z'),
+        createdAt: new Date('2026-01-12T17:30:00Z'),
+        updatedAt: new Date('2026-01-12T18:00:00Z'),
+        sales: {
+          id: 'sales-id-2',
+          salesName: '田中太郎',
+        },
+        visitRecords: [],
+        comments: [],
+      },
+    ]);
+
+    const url = new URL('http://localhost/api/reports');
+    const request = new NextRequest(url);
+
+    const response = await GET(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.status).toBe('success');
+    expect(data.data.items).toHaveLength(1);
+  });
+
+  it('営業担当者が他人の日報を取得しようとすると403エラー', async () => {
+    await mockAuth(false);
+
+    const url = new URL('http://localhost/api/reports?sales_id=507f1f77bcf86cd799439013');
+    const request = new NextRequest(url);
+
+    const response = await GET(request);
+
+    expect(response.status).toBe(403);
+  });
+
+  it('未認証の場合は401エラー', async () => {
+    await mockUnauthorized();
+
+    const url = new URL('http://localhost/api/reports');
+    const request = new NextRequest(url);
+
+    const response = await GET(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(data.status).toBe('error');
+  });
+
+  it('日付範囲でフィルタできる', async () => {
+    await mockAuth(false);
+
+    mockDailyReportCount.mockResolvedValue(1);
+    mockDailyReportFindMany.mockResolvedValue([
+      {
+        id: 'report-id-1',
+        salesId: 'sales-id-1',
+        reportDate: new Date('2026-01-12'),
+        problem: null,
+        plan: null,
+        status: 'DRAFT',
+        submittedAt: null,
+        createdAt: new Date('2026-01-12T17:30:00Z'),
+        updatedAt: new Date('2026-01-12T17:30:00Z'),
+        sales: {
+          id: 'sales-id-1',
+          salesName: '佐藤花子',
+        },
+        visitRecords: [],
+        comments: [],
+      },
+    ]);
+
+    const url = new URL('http://localhost/api/reports?start_date=2026-01-01&end_date=2026-01-31');
+    const request = new NextRequest(url);
+
+    const response = await GET(request);
+
+    expect(response.status).toBe(200);
+    expect(mockDailyReportFindMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          reportDate: expect.objectContaining({
+            gte: expect.any(Date),
+            lte: expect.any(Date),
+          }),
+        }),
+      })
+    );
+  });
+});
+
+describe('POST /api/reports', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('日報を作成できる', async () => {
+    await mockAuth(false);
+
+    mockDailyReportFindFirst.mockResolvedValue(null);
+    mockCustomerFindMany.mockResolvedValue([
+      { id: '507f1f77bcf86cd799439014' },
+      { id: '507f1f77bcf86cd799439015' },
+    ]);
+
+    const mockReport = {
+      id: 'report-id-1',
+      salesId: 'sales-id-1',
+      reportDate: new Date('2026-01-12'),
+      problem: '問題点',
+      plan: '翌日の予定',
+      status: 'SUBMITTED',
+      submittedAt: new Date('2026-01-12T18:00:00Z'),
+      createdAt: new Date('2026-01-12T17:30:00Z'),
+      updatedAt: new Date('2026-01-12T18:00:00Z'),
+    };
+
+    mockTransaction.mockImplementation(async (callback: any) => {
+      return await callback({
+        dailyReport: {
+          create: mockDailyReportCreate.mockResolvedValue(mockReport),
+        },
+        visitRecord: {
+          createMany: mockVisitRecordCreateMany.mockResolvedValue({ count: 2 }),
+        },
+      });
+    });
+
+    const requestBody = {
+      report_date: '2026-01-12',
+      problem: '問題点',
+      plan: '翌日の予定',
+      status: 'submitted',
+      visit_records: [
+        {
+          customer_id: '507f1f77bcf86cd799439014',
+          visit_datetime: '2026-01-12T10:00:00.000Z',
+          visit_content: '訪問内容1',
+          visit_result: '訪問結果1',
+          display_order: 1,
+        },
+        {
+          customer_id: '507f1f77bcf86cd799439015',
+          visit_datetime: '2026-01-12T14:00:00.000Z',
+          visit_content: '訪問内容2',
+          display_order: 2,
+        },
+      ],
+    };
+
+    const request = new NextRequest('http://localhost/api/reports', {
+      method: 'POST',
+      body: JSON.stringify(requestBody),
+    });
+
+    const response = await POST(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(201);
+    expect(data.status).toBe('success');
+    expect(data.data.report_id).toBe('report-id-1');
+    expect(data.data.status).toBe('submitted');
+  });
+
+  it('同一日付の日報が既に存在する場合は409エラー', async () => {
+    await mockAuth(false);
+
+    mockDailyReportFindFirst.mockResolvedValue({
+      id: 'existing-report-id',
+      salesId: 'sales-id-1',
+      reportDate: new Date('2026-01-12'),
+    });
+
+    const requestBody = {
+      report_date: '2026-01-12',
+      status: 'draft',
+      visit_records: [
+        {
+          customer_id: '507f1f77bcf86cd799439014',
+          visit_datetime: '2026-01-12T10:00:00.000Z',
+          visit_content: '訪問内容',
+          display_order: 1,
+        },
+      ],
+    };
+
+    const request = new NextRequest('http://localhost/api/reports', {
+      method: 'POST',
+      body: JSON.stringify(requestBody),
+    });
+
+    const response = await POST(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(409);
+    expect(data.status).toBe('error');
+    expect(data.error.code).toBe('RESOURCE_CONFLICT');
+  });
+
+  it('バリデーションエラー: 訪問記録が0件', async () => {
+    await mockAuth(false);
+
+    const requestBody = {
+      report_date: '2026-01-12',
+      status: 'draft',
+      visit_records: [],
+    };
+
+    const request = new NextRequest('http://localhost/api/reports', {
+      method: 'POST',
+      body: JSON.stringify(requestBody),
+    });
+
+    const response = await POST(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(data.status).toBe('error');
+    expect(data.error.code).toBe('VALIDATION_ERROR');
+  });
+
+  it('バリデーションエラー: 訪問記録が11件以上', async () => {
+    await mockAuth(false);
+
+    const requestBody = {
+      report_date: '2026-01-12',
+      status: 'draft',
+      visit_records: Array(11)
+        .fill(null)
+        .map((_, i) => ({
+          customer_id: '507f1f77bcf86cd799439014',
+          visit_datetime: '2026-01-12T10:00:00.000Z',
+          visit_content: `訪問内容${i + 1}`,
+          display_order: i + 1,
+        })),
+    };
+
+    const request = new NextRequest('http://localhost/api/reports', {
+      method: 'POST',
+      body: JSON.stringify(requestBody),
+    });
+
+    const response = await POST(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(data.status).toBe('error');
+    expect(data.error.code).toBe('VALIDATION_ERROR');
+  });
+
+  it('存在しない顧客IDの場合は400エラー', async () => {
+    await mockAuth(false);
+
+    mockDailyReportFindFirst.mockResolvedValue(null);
+    mockCustomerFindMany.mockResolvedValue([]);
+
+    const requestBody = {
+      report_date: '2026-01-12',
+      status: 'draft',
+      visit_records: [
+        {
+          customer_id: 'invalid-customer-id',
+          visit_datetime: '2026-01-12T10:00:00.000Z',
+          visit_content: '訪問内容',
+          display_order: 1,
+        },
+      ],
+    };
+
+    const request = new NextRequest('http://localhost/api/reports', {
+      method: 'POST',
+      body: JSON.stringify(requestBody),
+    });
+
+    const response = await POST(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(data.status).toBe('error');
+    expect(data.error.code).toBe('VALIDATION_ERROR');
+  });
+});

--- a/app/api/reports/route.ts
+++ b/app/api/reports/route.ts
@@ -147,21 +147,31 @@ export async function GET(request: NextRequest) {
           select: {
             id: true,
             isRead: true,
-            dailyReport: {
-              select: {
-                salesId: true,
-              },
-            },
+            commenterId: true,
           },
         },
       },
     });
 
+    // draft日報のフィルタリング: マネージャーは自分のdraftのみ、他人のdraftは除外
+    if (session.isManager && !targetSalesId) {
+      // 全員分を取得する場合は、他人のdraftを除外
+      reportList = reportList.filter((report) => {
+        if (report.status === 'DRAFT') {
+          return report.salesId === session.salesId;
+        }
+        return true; // submitted/commentedは全て表示
+      });
+    } else if (session.isManager && targetSalesId && targetSalesId !== session.salesId) {
+      // 特定の営業担当者を指定した場合も、そのdraftは除外
+      reportList = reportList.filter((report) => report.status !== 'DRAFT');
+    }
+
     // 未読コメントフィルタを適用（データ取得後にフィルタ）
     if (has_unread_comments !== undefined) {
       reportList = reportList.filter((report) => {
         const unreadCount = report.comments.filter(
-          (comment) => !comment.isRead && comment.dailyReport.salesId === report.salesId
+          (comment) => !comment.isRead && comment.commenterId !== report.salesId
         ).length;
         return has_unread_comments ? unreadCount > 0 : unreadCount === 0;
       });
@@ -172,7 +182,7 @@ export async function GET(request: NextRequest) {
       items: reportList.map((report) => {
         const hasComments = report.comments.length > 0;
         const unreadCommentCount = report.comments.filter(
-          (comment) => !comment.isRead && comment.dailyReport.salesId === report.salesId
+          (comment) => !comment.isRead && comment.commenterId !== report.salesId
         ).length;
 
         const statusMap: Record<string, 'draft' | 'submitted' | 'commented'> = {

--- a/app/api/reports/route.ts
+++ b/app/api/reports/route.ts
@@ -1,0 +1,382 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { PrismaClient, Prisma } from '@prisma/client';
+import { requireAuth } from '@/lib/middleware/auth';
+import {
+  reportListQuerySchema,
+  createReportSchema,
+  formatZodErrors,
+} from '@/lib/validations/report';
+import type { ApiSuccessResponse, ApiErrorResponse } from '@/types/session';
+import type { ReportListResponse, ReportCreateResponse } from '@/types/report';
+
+const prisma = new PrismaClient();
+
+/**
+ * 日報一覧取得API
+ *
+ * GET /api/reports
+ *
+ * 認証済みユーザーのみアクセス可能
+ * 管理者は全員分、営業担当者は自分の日報のみ取得可能
+ * クエリパラメータでフィルタリング・ページネーション可能
+ *
+ * @param request - Next.js Request オブジェクト
+ * @returns 日報一覧とページネーション情報
+ */
+export async function GET(request: NextRequest) {
+  try {
+    // 認証チェック
+    const authResult = await requireAuth();
+    if (authResult.error) {
+      return authResult.response;
+    }
+    const session = authResult.session;
+
+    // クエリパラメータの取得とバリデーション
+    const { searchParams } = new URL(request.url);
+    const queryParams = {
+      start_date: searchParams.get('start_date') || undefined,
+      end_date: searchParams.get('end_date') || undefined,
+      sales_id: searchParams.get('sales_id') || undefined,
+      status: searchParams.get('status') || undefined,
+      has_unread_comments: searchParams.get('has_unread_comments') || undefined,
+      page: searchParams.get('page') || '1',
+      limit: searchParams.get('limit') || '20',
+    };
+
+    const validationResult = reportListQuerySchema.safeParse(queryParams);
+    if (!validationResult.success) {
+      const errorResponse: ApiErrorResponse = {
+        status: 'error',
+        error: {
+          code: 'VALIDATION_ERROR',
+          message: '入力内容に誤りがあります',
+          details: formatZodErrors(validationResult.error),
+        },
+      };
+      return NextResponse.json(errorResponse, { status: 400 });
+    }
+
+    const { start_date, end_date, sales_id, status, has_unread_comments, page, limit } =
+      validationResult.data;
+
+    // 権限チェック: 営業担当者は自分の日報のみ、管理者は全員分または指定された営業の日報
+    let targetSalesId: string;
+    if (session.isManager) {
+      // 管理者の場合、sales_idが指定されていればそれを使用、なければ全員分
+      if (sales_id) {
+        targetSalesId = sales_id;
+      } else {
+        targetSalesId = ''; // 全員分を取得するための空文字
+      }
+    } else {
+      // 営業担当者の場合、自分の日報のみ
+      if (sales_id && sales_id !== session.salesId) {
+        const errorResponse: ApiErrorResponse = {
+          status: 'error',
+          error: {
+            code: 'AUTH_FORBIDDEN',
+            message: '権限がありません',
+          },
+        };
+        return NextResponse.json(errorResponse, { status: 403 });
+      }
+      targetSalesId = session.salesId;
+    }
+
+    // フィルタ条件の構築
+    const where: Prisma.DailyReportWhereInput = {};
+
+    // 営業IDフィルタ
+    if (targetSalesId) {
+      where.salesId = targetSalesId;
+    }
+
+    // 日付範囲フィルタ
+    if (start_date || end_date) {
+      where.reportDate = {};
+      if (start_date) {
+        where.reportDate.gte = new Date(start_date);
+      }
+      if (end_date) {
+        // end_dateは当日の23:59:59まで含める
+        const endDateTime = new Date(end_date);
+        endDateTime.setHours(23, 59, 59, 999);
+        where.reportDate.lte = endDateTime;
+      }
+    }
+
+    // ステータスフィルタ
+    if (status) {
+      const statusMap: Record<string, 'DRAFT' | 'SUBMITTED' | 'COMMENTED'> = {
+        draft: 'DRAFT',
+        submitted: 'SUBMITTED',
+        commented: 'COMMENTED',
+      };
+      where.status = statusMap[status];
+    }
+
+    // 総件数の取得
+    const totalItems = await prisma.dailyReport.count({ where });
+
+    // ページネーション計算
+    const totalPages = Math.ceil(totalItems / limit);
+    const skip = (page - 1) * limit;
+
+    // データ取得
+    let reportList = await prisma.dailyReport.findMany({
+      where,
+      skip,
+      take: limit,
+      orderBy: {
+        reportDate: 'desc',
+      },
+      include: {
+        sales: {
+          select: {
+            id: true,
+            salesName: true,
+          },
+        },
+        visitRecords: {
+          select: {
+            id: true,
+          },
+        },
+        comments: {
+          select: {
+            id: true,
+            isRead: true,
+            dailyReport: {
+              select: {
+                salesId: true,
+              },
+            },
+          },
+        },
+      },
+    });
+
+    // 未読コメントフィルタを適用（データ取得後にフィルタ）
+    if (has_unread_comments !== undefined) {
+      reportList = reportList.filter((report) => {
+        const unreadCount = report.comments.filter(
+          (comment) => !comment.isRead && comment.dailyReport.salesId === report.salesId
+        ).length;
+        return has_unread_comments ? unreadCount > 0 : unreadCount === 0;
+      });
+    }
+
+    // レスポンスの構築
+    const responseData: ReportListResponse = {
+      items: reportList.map((report) => {
+        const hasComments = report.comments.length > 0;
+        const unreadCommentCount = report.comments.filter(
+          (comment) => !comment.isRead && comment.dailyReport.salesId === report.salesId
+        ).length;
+
+        const statusMap: Record<string, 'draft' | 'submitted' | 'commented'> = {
+          DRAFT: 'draft',
+          SUBMITTED: 'submitted',
+          COMMENTED: 'commented',
+        };
+
+        return {
+          report_id: report.id,
+          report_date: report.reportDate.toISOString().split('T')[0],
+          sales: {
+            sales_id: report.sales.id,
+            sales_name: report.sales.salesName,
+          },
+          visit_count: report.visitRecords.length,
+          status: statusMap[report.status] || 'draft',
+          has_comments: hasComments,
+          unread_comment_count: unreadCommentCount,
+          submitted_at: report.submittedAt?.toISOString(),
+          created_at: report.createdAt.toISOString(),
+          updated_at: report.updatedAt.toISOString(),
+        };
+      }),
+      pagination: {
+        current_page: page,
+        total_pages: totalPages,
+        total_items: totalItems,
+        limit,
+      },
+    };
+
+    const successResponse: ApiSuccessResponse<ReportListResponse> = {
+      status: 'success',
+      data: responseData,
+    };
+
+    return NextResponse.json(successResponse, { status: 200 });
+  } catch (error) {
+    console.error('Report list retrieval error:', error);
+    const errorResponse: ApiErrorResponse = {
+      status: 'error',
+      error: {
+        code: 'SERVER_ERROR',
+        message: 'サーバーエラーが発生しました',
+      },
+    };
+    return NextResponse.json(errorResponse, { status: 500 });
+  } finally {
+    await prisma.$disconnect();
+  }
+}
+
+/**
+ * 日報作成API
+ *
+ * POST /api/reports
+ *
+ * 認証済みユーザーのみアクセス可能
+ * 営業ID×日付でユニークチェックを実施
+ * 訪問記録も同時に作成
+ *
+ * @param request - Next.js Request オブジェクト
+ * @returns 作成された日報情報
+ */
+export async function POST(request: NextRequest) {
+  try {
+    // 認証チェック
+    const authResult = await requireAuth();
+    if (authResult.error) {
+      return authResult.response;
+    }
+    const session = authResult.session;
+
+    // リクエストボディの取得
+    const body = await request.json();
+
+    // バリデーション
+    const validationResult = createReportSchema.safeParse(body);
+    if (!validationResult.success) {
+      const errorResponse: ApiErrorResponse = {
+        status: 'error',
+        error: {
+          code: 'VALIDATION_ERROR',
+          message: '入力内容に誤りがあります',
+          details: formatZodErrors(validationResult.error),
+        },
+      };
+      return NextResponse.json(errorResponse, { status: 400 });
+    }
+
+    const { report_date, problem, plan, status, visit_records } = validationResult.data;
+
+    // 日付の重複チェック（営業ID×日付でユニーク）
+    const reportDate = new Date(report_date);
+    const existingReport = await prisma.dailyReport.findFirst({
+      where: {
+        salesId: session.salesId,
+        reportDate: reportDate,
+      },
+    });
+
+    if (existingReport) {
+      const errorResponse: ApiErrorResponse = {
+        status: 'error',
+        error: {
+          code: 'RESOURCE_CONFLICT',
+          message: 'この日付の日報は既に存在します',
+        },
+      };
+      return NextResponse.json(errorResponse, { status: 409 });
+    }
+
+    // 顧客IDの存在確認
+    const customerIds = visit_records.map((record) => record.customer_id);
+    const customers = await prisma.customer.findMany({
+      where: {
+        id: {
+          in: customerIds,
+        },
+      },
+      select: {
+        id: true,
+      },
+    });
+
+    const foundCustomerIds = new Set(customers.map((c) => c.id));
+    const invalidCustomerIds = customerIds.filter((id) => !foundCustomerIds.has(id));
+
+    if (invalidCustomerIds.length > 0) {
+      const errorResponse: ApiErrorResponse = {
+        status: 'error',
+        error: {
+          code: 'VALIDATION_ERROR',
+          message: '入力内容に誤りがあります',
+          details: invalidCustomerIds.map((id) => ({
+            field: 'visit_records.customer_id',
+            message: `指定された顧客が見つかりません: ${id}`,
+          })),
+        },
+      };
+      return NextResponse.json(errorResponse, { status: 400 });
+    }
+
+    // ステータスマップ
+    const statusMap: Record<string, string> = {
+      draft: 'DRAFT',
+      submitted: 'SUBMITTED',
+    };
+
+    // 日報と訪問記録の作成（トランザクション）
+    const newReport = await prisma.$transaction(async (tx) => {
+      // 日報作成
+      const report = await tx.dailyReport.create({
+        data: {
+          salesId: session.salesId,
+          reportDate: reportDate,
+          problem: problem ?? null,
+          plan: plan ?? null,
+          status: (statusMap[status] as 'DRAFT' | 'SUBMITTED') || 'DRAFT',
+          submittedAt: status === 'submitted' ? new Date() : null,
+        },
+      });
+
+      // 訪問記録作成
+      await tx.visitRecord.createMany({
+        data: visit_records.map((record) => ({
+          reportId: report.id,
+          customerId: record.customer_id,
+          visitDatetime: new Date(record.visit_datetime),
+          visitContent: record.visit_content,
+          visitResult: record.visit_result ?? null,
+          displayOrder: record.display_order,
+        })),
+      });
+
+      return report;
+    });
+
+    // レスポンスの構築
+    const responseData: ReportCreateResponse = {
+      report_id: newReport.id,
+      report_date: newReport.reportDate.toISOString().split('T')[0],
+      status: status,
+      created_at: newReport.createdAt.toISOString(),
+    };
+
+    const successResponse: ApiSuccessResponse<ReportCreateResponse> = {
+      status: 'success',
+      data: responseData,
+    };
+
+    return NextResponse.json(successResponse, { status: 201 });
+  } catch (error) {
+    console.error('Report creation error:', error);
+    const errorResponse: ApiErrorResponse = {
+      status: 'error',
+      error: {
+        code: 'SERVER_ERROR',
+        message: 'サーバーエラーが発生しました',
+      },
+    };
+    return NextResponse.json(errorResponse, { status: 500 });
+  } finally {
+    await prisma.$disconnect();
+  }
+}

--- a/app/api/reports/unread-comments/count/__tests__/route.test.ts
+++ b/app/api/reports/unread-comments/count/__tests__/route.test.ts
@@ -1,0 +1,120 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { GET } from '../route';
+import { NextRequest } from 'next/server';
+
+// vi.hoisted を使ってモック関数を定義
+const mockCommentCount = vi.hoisted(() => vi.fn());
+const mockDisconnect = vi.hoisted(() => vi.fn());
+
+// モックの設定
+vi.mock('@prisma/client', () => {
+  class MockPrismaClient {
+    comment = {
+      count: mockCommentCount,
+    };
+    $disconnect = mockDisconnect;
+  }
+
+  return {
+    PrismaClient: MockPrismaClient,
+  };
+});
+
+vi.mock('@/lib/middleware/auth', () => ({
+  requireAuth: vi.fn(),
+}));
+
+// テスト用のヘルパー関数
+const mockAuth = async () => {
+  const { requireAuth } = await import('@/lib/middleware/auth');
+  vi.mocked(requireAuth).mockResolvedValue({
+    session: {
+      salesId: '507f1f77bcf86cd799439012',
+      salesCode: 'S001',
+      salesName: '佐藤花子',
+      email: 'sato@example.com',
+      department: '営業1課',
+      isManager: false,
+      expiresAt: Date.now() + 30 * 60 * 1000,
+    },
+    error: null,
+  } as any);
+};
+
+const mockUnauthorized = async () => {
+  const { requireAuth } = await import('@/lib/middleware/auth');
+  const errorResponse = {
+    status: 'error',
+    error: {
+      code: 'AUTH_UNAUTHORIZED',
+      message: '認証が必要です',
+    },
+  };
+
+  vi.mocked(requireAuth).mockResolvedValue({
+    session: null,
+    error: true,
+    response: {
+      json: () => Promise.resolve(errorResponse),
+      status: 401,
+    } as any,
+  });
+};
+
+describe('GET /api/reports/unread-comments/count', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('未読コメント数を取得できる', async () => {
+    await mockAuth();
+
+    mockCommentCount.mockResolvedValue(5);
+
+    const request = new NextRequest('http://localhost/api/reports/unread-comments/count');
+
+    const response = await GET(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.status).toBe('success');
+    expect(data.data.unread_count).toBe(5);
+    expect(mockCommentCount).toHaveBeenCalledWith({
+      where: {
+        dailyReport: {
+          salesId: '507f1f77bcf86cd799439012',
+        },
+        isRead: false,
+      },
+    });
+  });
+
+  it('未読コメントが0件の場合', async () => {
+    await mockAuth();
+
+    mockCommentCount.mockResolvedValue(0);
+
+    const request = new NextRequest('http://localhost/api/reports/unread-comments/count');
+
+    const response = await GET(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.status).toBe('success');
+    expect(data.data.unread_count).toBe(0);
+  });
+
+  it('未認証の場合は401エラー', async () => {
+    await mockUnauthorized();
+
+    const request = new NextRequest('http://localhost/api/reports/unread-comments/count');
+
+    const response = await GET(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(data.status).toBe('error');
+    expect(data.error.code).toBe('AUTH_UNAUTHORIZED');
+  });
+});

--- a/app/api/reports/unread-comments/count/route.ts
+++ b/app/api/reports/unread-comments/count/route.ts
@@ -1,0 +1,63 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { PrismaClient } from '@prisma/client';
+import { requireAuth } from '@/lib/middleware/auth';
+import type { ApiSuccessResponse, ApiErrorResponse } from '@/types/session';
+import type { UnreadCommentsCountResponse } from '@/types/report';
+
+const prisma = new PrismaClient();
+
+/**
+ * 未読コメント数取得API
+ *
+ * GET /api/reports/unread-comments/count
+ *
+ * 認証済みユーザーのみアクセス可能
+ * 自分の日報に対する未読コメント数を取得
+ *
+ * @param request - Next.js Request オブジェクト
+ * @returns 未読コメント数
+ */
+export async function GET(_request: NextRequest) {
+  try {
+    // 認証チェック
+    const authResult = await requireAuth();
+    if (authResult.error) {
+      return authResult.response;
+    }
+    const session = authResult.session;
+
+    // 自分の日報に対する未読コメント数を取得
+    const unreadCount = await prisma.comment.count({
+      where: {
+        dailyReport: {
+          salesId: session.salesId,
+        },
+        isRead: false,
+      },
+    });
+
+    // レスポンスの構築
+    const responseData: UnreadCommentsCountResponse = {
+      unread_count: unreadCount,
+    };
+
+    const successResponse: ApiSuccessResponse<UnreadCommentsCountResponse> = {
+      status: 'success',
+      data: responseData,
+    };
+
+    return NextResponse.json(successResponse, { status: 200 });
+  } catch (error) {
+    console.error('Unread comments count retrieval error:', error);
+    const errorResponse: ApiErrorResponse = {
+      status: 'error',
+      error: {
+        code: 'SERVER_ERROR',
+        message: 'サーバーエラーが発生しました',
+      },
+    };
+    return NextResponse.json(errorResponse, { status: 500 });
+  } finally {
+    await prisma.$disconnect();
+  }
+}

--- a/lib/validations/report.ts
+++ b/lib/validations/report.ts
@@ -1,0 +1,152 @@
+import { z } from 'zod';
+
+/**
+ * 日付のバリデーション（YYYY-MM-DD形式）
+ */
+export const reportDateSchema = z
+  .string()
+  .min(1, '日報日付は必須です')
+  .regex(/^\d{4}-\d{2}-\d{2}$/, '日報日付はYYYY-MM-DD形式で入力してください');
+
+/**
+ * ISO 8601日時のバリデーション
+ */
+export const iso8601DatetimeSchema = z
+  .string()
+  .min(1, '訪問日時は必須です')
+  .datetime({ message: '訪問日時は正しい日時形式で入力してください' });
+
+/**
+ * 問題点のバリデーション
+ * - 最大1000文字
+ */
+export const problemSchema = z
+  .string()
+  .max(1000, '問題点は1000文字以内で入力してください')
+  .optional();
+
+/**
+ * 翌日の予定のバリデーション
+ * - 最大1000文字
+ */
+export const planSchema = z
+  .string()
+  .max(1000, '翌日の予定は1000文字以内で入力してください')
+  .optional();
+
+/**
+ * ステータスのバリデーション
+ * - draft（下書き）またはsubmitted（提出済み）
+ */
+export const reportStatusSchema = z.enum(['draft', 'submitted'], {
+  message: 'ステータスはdraftまたはsubmittedのいずれかを指定してください',
+});
+
+/**
+ * 訪問内容のバリデーション
+ * - 必須
+ * - 最大500文字
+ */
+export const visitContentSchema = z
+  .string()
+  .min(1, '訪問内容は必須です')
+  .max(500, '訪問内容は500文字以内で入力してください');
+
+/**
+ * 訪問結果のバリデーション
+ * - 最大500文字
+ */
+export const visitResultSchema = z
+  .string()
+  .max(500, '訪問結果は500文字以内で入力してください')
+  .optional();
+
+/**
+ * MongoDB ObjectIdのバリデーション
+ */
+export const objectIdSchema = z.string().regex(/^[0-9a-fA-F]{24}$/, '無効なIDです');
+
+/**
+ * 訪問記録のスキーマ（作成時）
+ */
+export const visitRecordCreateSchema = z.object({
+  customer_id: objectIdSchema,
+  visit_datetime: iso8601DatetimeSchema,
+  visit_content: visitContentSchema,
+  visit_result: visitResultSchema,
+  display_order: z.number().int().min(1, '表示順は1以上の整数で指定してください'),
+});
+
+/**
+ * 訪問記録のスキーマ（更新時）
+ * visit_idがある場合は既存レコードの更新、ない場合は新規作成
+ */
+export const visitRecordUpdateSchema = z.object({
+  visit_id: objectIdSchema.optional(),
+  customer_id: objectIdSchema,
+  visit_datetime: iso8601DatetimeSchema,
+  visit_content: visitContentSchema,
+  visit_result: visitResultSchema,
+  display_order: z.number().int().min(1, '表示順は1以上の整数で指定してください'),
+});
+
+/**
+ * 日報作成リクエストのスキーマ
+ */
+export const createReportSchema = z
+  .object({
+    report_date: reportDateSchema,
+    problem: problemSchema,
+    plan: planSchema,
+    status: reportStatusSchema,
+    visit_records: z
+      .array(visitRecordCreateSchema)
+      .min(1, '訪問記録は1件以上必要です')
+      .max(10, '訪問記録は最大10件までです'),
+  })
+  .strict();
+
+/**
+ * 日報更新リクエストのスキーマ
+ */
+export const updateReportSchema = z
+  .object({
+    problem: problemSchema,
+    plan: planSchema,
+    status: reportStatusSchema,
+    visit_records: z
+      .array(visitRecordUpdateSchema)
+      .min(1, '訪問記録は1件以上必要です')
+      .max(10, '訪問記録は最大10件までです'),
+  })
+  .strict();
+
+/**
+ * 日報一覧取得クエリパラメータのスキーマ
+ */
+export const reportListQuerySchema = z.object({
+  start_date: reportDateSchema.optional(),
+  end_date: reportDateSchema.optional(),
+  sales_id: objectIdSchema.optional(),
+  status: z.enum(['draft', 'submitted', 'commented']).optional(),
+  has_unread_comments: z
+    .string()
+    .transform((val) => val === 'true')
+    .pipe(z.boolean())
+    .optional(),
+  page: z.coerce.number().int().min(1).default(1),
+  limit: z.coerce.number().int().min(1).max(100).default(20),
+});
+
+/**
+ * Zodエラーから詳細なエラーメッセージを抽出する
+ */
+export function formatZodErrors(error: z.ZodError): Array<{ field: string; message: string }> {
+  if (!error || !error.issues || !Array.isArray(error.issues)) {
+    return [];
+  }
+  return error.issues.map((err) => ({
+    field: err.path.join('.'),
+    message: err.message,
+  }));
+}

--- a/types/report.ts
+++ b/types/report.ts
@@ -1,0 +1,164 @@
+/**
+ * 日報APIのレスポンス型定義
+ */
+
+/**
+ * 日報一覧の各アイテム
+ */
+export interface ReportListItem {
+  report_id: string;
+  report_date: string;
+  sales: {
+    sales_id: string;
+    sales_name: string;
+  };
+  visit_count: number;
+  status: 'draft' | 'submitted' | 'commented';
+  has_comments: boolean;
+  unread_comment_count: number;
+  submitted_at?: string;
+  created_at: string;
+  updated_at: string;
+}
+
+/**
+ * 日報一覧取得レスポンス
+ */
+export interface ReportListResponse {
+  items: ReportListItem[];
+  pagination: {
+    current_page: number;
+    total_pages: number;
+    total_items: number;
+    limit: number;
+  };
+}
+
+/**
+ * 訪問記録（詳細）
+ */
+export interface VisitRecord {
+  visit_id: string;
+  customer: {
+    customer_id: string;
+    customer_code: string;
+    customer_name: string;
+  };
+  visit_datetime: string;
+  visit_content: string;
+  visit_result?: string;
+  display_order: number;
+}
+
+/**
+ * コメント情報
+ */
+export interface Comment {
+  comment_id: string;
+  commenter: {
+    sales_id: string;
+    sales_name: string;
+  };
+  comment_text: string;
+  is_read: boolean;
+  read_at?: string;
+  created_at: string;
+}
+
+/**
+ * コメント（問題点・翌日の予定別）
+ */
+export interface CommentsByType {
+  problem: Comment[];
+  plan: Comment[];
+}
+
+/**
+ * 日報詳細取得レスポンス
+ */
+export interface ReportDetailResponse {
+  report_id: string;
+  report_date: string;
+  sales: {
+    sales_id: string;
+    sales_name: string;
+    department: string;
+  };
+  problem?: string;
+  plan?: string;
+  status: 'draft' | 'submitted' | 'commented';
+  submitted_at?: string;
+  visit_records: VisitRecord[];
+  comments: CommentsByType;
+  created_at: string;
+  updated_at: string;
+}
+
+/**
+ * 日報作成レスポンス
+ */
+export interface ReportCreateResponse {
+  report_id: string;
+  report_date: string;
+  status: 'draft' | 'submitted';
+  created_at: string;
+}
+
+/**
+ * 日報更新レスポンス
+ */
+export interface ReportUpdateResponse {
+  report_id: string;
+  updated_at: string;
+}
+
+/**
+ * 未読コメント数レスポンス
+ */
+export interface UnreadCommentsCountResponse {
+  unread_count: number;
+}
+
+/**
+ * 訪問記録作成リクエスト
+ */
+export interface VisitRecordCreateRequest {
+  customer_id: string;
+  visit_datetime: string;
+  visit_content: string;
+  visit_result?: string;
+  display_order: number;
+}
+
+/**
+ * 訪問記録更新リクエスト
+ */
+export interface VisitRecordUpdateRequest {
+  visit_id?: string;
+  customer_id: string;
+  visit_datetime: string;
+  visit_content: string;
+  visit_result?: string;
+  display_order: number;
+}
+
+/**
+ * 日報作成リクエスト
+ */
+export interface ReportCreateRequest {
+  report_date: string;
+  problem?: string;
+  plan?: string;
+  status: 'draft' | 'submitted';
+  visit_records: VisitRecordCreateRequest[];
+}
+
+/**
+ * 日報更新リクエスト
+ */
+export interface ReportUpdateRequest {
+  problem?: string;
+  plan?: string;
+  status: 'draft' | 'submitted';
+  visit_records: VisitRecordUpdateRequest[];
+}


### PR DESCRIPTION
## Summary
Issue #14に基づいて日報管理のAPIエンドポイントを実装しました。

- GET /api/reports: 日報一覧取得（ページネーション、検索、権限制御）
- GET /api/reports/:id: 日報詳細取得（訪問記録、コメント含む）
- POST /api/reports: 日報作成（訪問記録含む、営業ID×日付でユニーク）
- PUT /api/reports/:id: 日報更新（訪問記録の差分更新、権限チェック）
- DELETE /api/reports/:id: 日報削除（権限チェック）
- GET /api/reports/unread-comments/count: 未読コメント数取得

## 実装内容

### 新規ファイル
- `lib/validations/report.ts`: Zodバリデーションスキーマ
- `types/report.ts`: 日報関連の型定義
- `app/api/reports/route.ts`: 日報一覧取得・作成API
- `app/api/reports/[id]/route.ts`: 日報詳細取得・更新・削除API
- `app/api/reports/unread-comments/count/route.ts`: 未読コメント数取得API
- `app/api/reports/__tests__/route.test.ts`: 一覧・作成APIのテスト
- `app/api/reports/[id]/__tests__/route.test.ts`: 詳細・更新・削除APIのテスト
- `app/api/reports/unread-comments/count/__tests__/route.test.ts`: 未読コメント数取得APIのテスト

### バリデーション要件（すべて実装済み）
- ✅ report_date: 必須、日付形式、営業ID×日付でユニーク
- ✅ problem: 1000文字以内
- ✅ plan: 1000文字以内
- ✅ status: 必須、draft/submitted
- ✅ visit_records: 必須（1件以上）、最大10件
- ✅ visit_records.customer_id: 必須
- ✅ visit_records.visit_datetime: 必須、日時形式
- ✅ visit_records.visit_content: 必須、500文字以内
- ✅ visit_records.visit_result: 500文字以内

### 権限制御
- 管理者：全員分の日報を取得可能
- 営業担当者：自分の日報のみ取得・更新・削除可能
- 更新・削除時に所有者チェックを実施

### 訪問記録の差分更新
- visit_idあり：既存レコード更新
- visit_idなし：新規レコード作成
- リクエストに含まれない既存レコード：削除

## Test plan
- [x] 全24テストが成功
- [x] 型チェックが成功
- [x] Lintが成功
- [x] 既存テスト（474テスト）が全てパス

## 関連Issue
Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)